### PR TITLE
Document manual rotation process for asymmetric KMS signing keys

### DIFF
--- a/modulo6_kms_hsm/03_implementacao_kms_cartorio.md
+++ b/modulo6_kms_hsm/03_implementacao_kms_cartorio.md
@@ -29,3 +29,21 @@ signature = sign_response['Signature']
 ### Integração prática
 Cada **documento assinado** usa uma **data key** derivada de uma CMK (envelope encryption)
 para garantir segregação e rastreabilidade.
+
+### Provisionamento com Terraform
+```hcl
+resource "aws_kms_key" "assinatura_cartorio" {
+  description             = "Chave KMS para assinatura do Cartório Digital"
+  key_usage               = "SIGN_VERIFY"
+  customer_master_key_spec = "RSA_2048"
+  deletion_window_in_days = 30
+}
+
+resource "aws_kms_alias" "assinatura_cartorio" {
+  name          = "alias/cartorio-assinatura"
+  target_key_id = aws_kms_key.assinatura_cartorio.key_id
+}
+```
+As chaves assimétricas de assinatura (`KeyUsage = "SIGN_VERIFY"`) com `customer_master_key_spec = "RSA_2048"` **não** suportam rotação automática; por isso, a opção `enable_key_rotation` não aparece no recurso acima.
+
+> **Planejamento de rotação manual:** para renovar chaves de assinatura, crie uma nova CMK com as mesmas características, atualize a aplicação/alias para apontar para a nova chave, valide as novas assinaturas e, somente após a transição completa, desative e agende a exclusão da chave antiga. Registre o processo e mantenha evidências de teste para auditoria.

--- a/modulo6_kms_hsm/05_praticas_auditoria_rotacao.md
+++ b/modulo6_kms_hsm/05_praticas_auditoria_rotacao.md
@@ -6,8 +6,20 @@
 - Alertas com **CloudWatch**.
 - Verificação de integridade com hashes/assinaturas cruzadas.
 
-### Exemplo prático
+## Políticas de rotação por tipo de chave
+
+### Chaves simétricas (ENCRYPT_DECRYPT)
+- Habilite a rotação automática fornecida pelo KMS.
+- Documente no runbook a revisão anual do agendamento.
 ```python
-kms.enable_key_rotation(KeyId=key_id)
-print("Rotação de chave ativada:", key_id)
+key_metadata = kms.describe_key(KeyId=key_id)["KeyMetadata"]
+if key_metadata["KeyUsage"] == "ENCRYPT_DECRYPT":
+    kms.enable_key_rotation(KeyId=key_id)
+    print("Rotação automática habilitada:", key_id)
 ```
+
+### Chaves assimétricas (SIGN_VERIFY)
+- Não existe rotação automática; mantenha um processo manual documentado.
+- Planeje a criação antecipada de uma nova CMK e a troca controlada do alias/ARN nas aplicações.
+- Valide as novas assinaturas antes de desativar a chave antiga e arquive as evidências de teste para auditoria.
+- Após a migração, desabilite a chave anterior e agende sua exclusão conforme as políticas de retenção.


### PR DESCRIPTION
## Summary
- clarify the Terraform provisioning example for KMS signing keys, explaining why `enable_key_rotation` is omitted and how to plan manual rotation
- differentiate rotation guidance for symmetric versus asymmetric keys in the auditing practices module

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e5642a8994832888944a34082745f3