### PR TITLE
Add cloud CI/CD module narrative and guided exercises

### DIFF
--- a/modulo8_cloud_cicd/01_visao_estrategica.md
+++ b/modulo8_cloud_cicd/01_visao_estrategica.md
@@ -1,0 +1,51 @@
+# 01 · Visão estratégica da jornada em nuvem
+
+O cartório digital nasce para garantir confiança, rastreabilidade e segurança aos atos jurídicos de cidadãos e empresas. Ao chegar ao módulo de Cloud e CI/CD, carregamos a experiência dos módulos anteriores — onde modelamos certificados, automações e observabilidade — e nos deparamos com o desafio de escalar tudo isso de forma resiliente e repetível. Este capítulo inspira a equipe a enxergar a nuvem e os pipelines como aliados para acelerar entregas sem abrir mão da conformidade regulatória.
+
+## Desafio
+
+Como levar o serviço de emissão de certidões, autenticações e selos digitais para a nuvem com ciclos de entrega contínua e controles robustos? Precisamos garantir que cada push de código possa seguir um fluxo seguro até a produção, mantendo criptografia forte e auditabilidade em cada etapa.
+
+## Estratégia orientadora
+
+1. **Padronizar pipelines**: Definimos uma cadência única para construção, testes e implantação usando GitHub Actions, facilitando o reuso entre squads.
+2. **Infraestrutura como código**: Representamos a topologia do cartório digital com Terraform para que ambientes sejam criados em minutos, e não em dias.
+3. **Observabilidade integrada**: Conectamos logs, métricas e alertas para reagir rápido a qualquer ameaça à disponibilidade.
+
+## Exemplo inspirador
+
+Antes de automatizar, revisamos como os módulos anteriores alimentam esta fase:
+
+- As práticas de certificação de `modulo2` e segurança de transporte de `modulo3` são insumos do pipeline.
+- As integrações regulatórias de `modulo5` e a governança de chaves de `modulo6` definem políticas de aprovação.
+- A assinatura de artefatos de `modulo7` garante confiabilidade nas imagens Docker liberadas pelo pipeline.
+
+Para consolidar essa visão, iniciamos um fluxo de trabalho GitHub Actions minimalista que aciona builds consistentes:
+
+```yaml
+# .github/workflows/cartorio-ci.yml
+name: Cartorio Digital CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configurar versão do Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Executar testes
+        run: npm test
+```
+
+Essa base permite que cada mudança de código percorra uma trilha confiável, reforçando o compromisso do cartório digital com entregas frequentes e seguras.
+
+## Conexão com o projeto final
+
+Ao dominar essa visão estratégica, o time consegue desenhar a esteira que sustentará a implantação completa apresentada no `modulo10_projeto_final`. Todo o ecossistema passa a falar a mesma linguagem de automação, habilitando auditorias rápidas e confiança do cidadão digital.

--- a/modulo8_cloud_cicd/02_pipelines_cartorio.md
+++ b/modulo8_cloud_cicd/02_pipelines_cartorio.md
@@ -1,0 +1,85 @@
+# 02 · Pipelines do cartório digital
+
+Neste capítulo, transformamos a visão estratégica em uma esteira viva que entrega valor diariamente. A missão do cartório digital é liberar certidões e atos com rapidez, sem abrir mão da segurança jurídica. Para isso, construímos pipelines que unem testes automatizados, assinatura de artefatos e implantação contínua.
+
+## Cenário
+
+Os repositórios do cartório concentram microserviços responsáveis por autenticação, registros e integrações externas. Cada alteração precisa ser validada quanto a conformidade, performance e segurança. A equipe deseja uma solução que reduza erros manuais e garanta rastreabilidade.
+
+## Abordagem com GitHub Actions
+
+Adotamos GitHub Actions por sua integração nativa com GitHub e por permitir workflows sofisticados com gates de aprovação. A seguir, apresentamos um pipeline que compila, testa, assina e implanta componentes do cartório.
+
+### Configuração passo a passo
+
+1. **Definir variáveis sensíveis**: No repositório principal, adicionamos `ACME_ACCOUNT_KEY`, `AWS_ROLE_ARN` e `SIGNING_KEY_ID` como *secrets*.
+2. **Estruturar jobs em estágios**: Criamos estágios de `build`, `security`, `sign` e `deploy`, com dependências claras.
+3. **Registrar artefatos**: Utilizamos GitHub Packages e Amazon ECR para armazenar imagens e assinaturas.
+
+### Exemplo guiado
+
+```yaml
+# .github/workflows/cartorio-delivery.yml
+name: Cartorio Delivery Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Instalar dependências
+        run: npm ci
+      - name: Executar testes unitários
+        run: npm test
+      - name: Publicar relatórios
+        uses: actions/upload-artifact@v4
+        with:
+          name: relatorios-testes
+          path: coverage/
+
+  security:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Análise SCA
+        uses: github/codeql-action/analyze@v3
+      - name: Escanear contêiner
+        run: |
+          trivy image --exit-code 1 ghcr.io/cartorio-digital/api:latest
+
+  sign:
+    needs: security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Baixar imagem
+        run: docker pull ghcr.io/cartorio-digital/api:latest
+      - name: Assinar artefato com Sigstore
+        run: cosign sign --key ${{ secrets.SIGNING_KEY_ID }} ghcr.io/cartorio-digital/api:latest
+
+  deploy:
+    needs: sign
+    runs-on: ubuntu-latest
+    environment:
+      name: producao
+      url: https://api.cartorio.digital
+    steps:
+      - name: Configurar credenciais AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Implantar com CDK
+        run: npx cdk deploy CartorioStack --require-approval never
+```
+
+Cada bloco é precedido por revisões manuais quando necessário, reforçando governança. O pipeline produz trilhas auditáveis que alimentam a área de conformidade, conectando com os requisitos vistos no `modulo5_regulatorio`.
+
+## Relacionamento com o projeto principal
+
+As mesmas etapas acima alimentam o *blueprint* do `modulo10_projeto_final`, onde consolidaremos a automação ponta a ponta — do commit à emissão de certidões em ambiente multirregional.

--- a/modulo8_cloud_cicd/03_iac_nuvem.md
+++ b/modulo8_cloud_cicd/03_iac_nuvem.md
@@ -1,0 +1,65 @@
+# 03 · Infraestrutura como código na nuvem
+
+A nuvem é o terreno fértil onde o cartório digital floresce. Para manter consistência entre ambientes, convertemos recursos de rede, segurança e aplicação em código. Este capítulo motiva a equipe a ver a infraestrutura como parte integrante do software, permitindo criar e desfazer ambientes com a mesma disciplina aplicada ao código-fonte.
+
+## Problema a resolver
+
+Manter ambientes idênticos entre homologação e produção é essencial para evitar surpresas durante a emissão de certidões. Alterações manuais em consoles dificultam auditorias e podem comprometer a conformidade exigida pelos órgãos reguladores.
+
+## Escolha do Terraform
+
+Optamos por Terraform pela sua linguagem declarativa e amplo ecossistema de provedores. Com ele, descrevemos VPCs, balanceadores, certificados e funções serverless que sustentam o cartório digital.
+
+## Exemplo guiado
+
+Antes de escrever código, alinhamos a arquitetura mínima:
+
+1. **Rede segura** com VPC, sub-redes públicas para load balancers e privadas para serviços.
+2. **Balanceador com HTTPS** associado a certificado emitido pela autoridade interna (módulos 2 e 6).
+3. **Serviço containerizado** (ECS ou EKS) recebendo as imagens validadas no módulo de pipelines.
+
+O trecho abaixo demonstra a criação de um Application Load Balancer protegido por TLS usando Terraform.
+
+```hcl
+# infrastructure/load_balancer.tf
+resource "aws_lb" "cartorio" {
+  name               = "cartorio-alb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = aws_subnet.public.*.id
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.cartorio.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = aws_acm_certificate.cartorio.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.cartorio.arn
+  }
+}
+
+resource "aws_acm_certificate" "cartorio" {
+  domain_name       = "api.cartorio.digital"
+  validation_method = "DNS"
+}
+```
+
+### Aplicando o plano
+
+```bash
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+Cada execução gera logs versionados que comprovam quem alterou o ambiente e quando. Este material é compartilhado com a equipe regulatória, reforçando os controles apresentados em `modulo5_regulatorio`.
+
+## Integração com outros módulos
+
+- O módulo de automação (`modulo4_automacao`) fornece scripts que disparam o `terraform apply` após aprovações.
+- O módulo de observabilidade (`modulo9_observabilidade`) consome *tags* e *outputs* definidos aqui para montar dashboards de saúde da infraestrutura.
+
+Com a infraestrutura sob controle de versão, o cartório digital conquista previsibilidade e pode ampliar sua atuação para novas regiões com confiança.

--- a/modulo8_cloud_cicd/04_observabilidade_alertas.md
+++ b/modulo8_cloud_cicd/04_observabilidade_alertas.md
@@ -1,0 +1,71 @@
+# 04 · Observabilidade e alertas em pipelines cloud
+
+Com a aplicação do cartório digital processando milhares de transações por dia, enxergar o que acontece sob o capô é vital. Este capítulo mostra como nutrimos uma cultura observável, onde métricas, logs e alertas transformam dados em decisões rápidas.
+
+## Contexto
+
+Certificados expiram, pipelines podem falhar e recursos em nuvem sofrem oscilações. Sem monitoramento proativo, corremos o risco de comprometer a confiança dos cidadãos. Precisamos instrumentar cada etapa para detectar incidentes antes que eles impactem o serviço.
+
+## Estratégia de observabilidade
+
+1. **Coletar métricas do pipeline**: Exportamos dados do GitHub Actions para o Prometheus do cartório.
+2. **Monitorar certificados**: Reutilizamos scripts do `modulo3_tls_mtls` para verificar validade e publicar métricas.
+3. **Alertas acionáveis**: Definimos gatilhos no Grafana que notificam o time via Slack e PagerDuty.
+
+## Exemplo guiado com Prometheus e Grafana
+
+Primeiro, configuramos um *exporter* que captura resultados dos jobs:
+
+```yaml
+# .github/workflows/metrics-export.yml
+name: Exportar métricas do pipeline
+
+on:
+  workflow_run:
+    workflows: ["Cartorio Delivery Pipeline"]
+    types:
+      - completed
+
+jobs:
+  publicar-metricas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enviar métricas para Prometheus Pushgateway
+        run: |
+          echo "pipeline_status{workflow=\"delivery\"} ${{ github.event.workflow_run.conclusion == 'success' && 1 || 0 }}" \
+            | curl --data-binary @- https://observabilidade.cartorio.digital/metrics
+```
+
+Em seguida, criamos uma regra de alerta no Grafana que dispara quando o pipeline falha três vezes consecutivas:
+
+```hcl
+# grafana/provisioning/alerting/cartorio-pipeline.json
+{
+  "title": "Falhas consecutivas no pipeline",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "timeSeriesQuery",
+      "relativeTimeRange": {"from": 900, "to": 0},
+      "datasourceUid": "prometheus",
+      "model": {
+        "expr": "sum_over_time(pipeline_status{workflow=\"delivery\"} == 0 [15m]) >= 3"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "Alerting",
+  "for": "0m",
+  "annotations": {
+    "summary": "Pipeline do cartório falhou 3 vezes em 15 minutos"
+  },
+  "contactPoints": ["slack-cartorio", "pagerduty-certidoes"]
+}
+```
+
+## Ligação com alertas de certificados
+
+A mesma pilha de observabilidade acompanha os prazos de certificados definidos nos módulos anteriores. Um job adicional lê o `terraform state` para identificar recursos ACM e publica métricas de expiração, reforçando a proteção destacada em `modulo6_kms_hsm`.
+
+Com dados confiáveis e alertas acionáveis, o cartório digital preserva sua reputação e mantém a operação sob controle, mesmo diante de picos de demanda.

--- a/modulo8_cloud_cicd/05_desafio_final.md
+++ b/modulo8_cloud_cicd/05_desafio_final.md
@@ -1,0 +1,33 @@
+# 05 · Desafio final do módulo
+
+Para coroar o módulo de Cloud e CI/CD, propomos um desafio que conecta cada peça construída até aqui. É a oportunidade de demonstrar que o cartório digital está pronto para operar em escala nacional, com pipelines confiáveis, infraestrutura resiliente e observabilidade ativa.
+
+## Objetivo do desafio
+
+Construir uma release completa do cartório digital, desde o commit até a publicação em ambiente de produção, incluindo monitoramento pós-implantação e documentação das decisões. O resultado deve provar que o time domina automações seguras e pode responder rapidamente a incidentes.
+
+## Entregáveis esperados
+
+1. **Pipeline orquestrado** que inclua build, testes, segurança, assinatura, provisionamento e deploy.
+2. **Infraestrutura como código** com Terraform ou AWS CDK versionado e acompanhado de *pipelines* de `plan` e `apply`.
+3. **Stack de observabilidade** com alertas de expiração de certificados e falhas de deploy.
+4. **Relatório executivo** apresentando ganhos de velocidade, confiabilidade e conformidade.
+
+## Roteiro sugerido
+
+1. **Preparar o repositório**
+   - Revisar *secrets*, variáveis e branch protection rules.
+   - Conectar repositórios de módulos anteriores para reutilizar componentes (scripts de assinatura, templates Terraform, dashboards).
+2. **Executar o pipeline completo**
+   - Disparar o workflow `Cartorio Delivery Pipeline` com uma alteração real (ex.: atualização de schema de certidão).
+   - Registrar evidências de cada etapa (logs, artefatos, prints de dashboards).
+3. **Validar operação em produção**
+   - Usar scripts do `modulo3_tls_mtls` para confirmar que certificados foram renovados.
+   - Monitorar alertas no Grafana e responder a uma simulação de incidente.
+4. **Apresentar lições aprendidas**
+   - Documentar como os controles do `modulo5_regulatorio` foram atendidos.
+   - Sugerir melhorias para o `modulo10_projeto_final`.
+
+## Inspiração para a apresentação final
+
+Encerre com uma demo onde o pipeline é acionado ao vivo, o Terraform cria recursos e o dashboard confirma a saúde do ambiente. Mostre como cada módulo contribuiu para um ecossistema confiável, reforçando que o cartório digital está apto a proteger a cidadania digital do país.

--- a/modulo8_cloud_cicd/README.md
+++ b/modulo8_cloud_cicd/README.md
@@ -1,6 +1,18 @@
 # Módulo 8 – Implantacao em Cloud e CI/CD
 
-O cartório digital precisa ser implantado com agilidade e segurança em ambientes de produção.  Neste módulo você irá integrar o projeto com pipelines de integração e entrega contínua (CI/CD) e preparar a infraestrutura em nuvem (AWS, Azure ou outra) para o uso de certificados automatizados.
+O cartório digital precisa ser implantado com agilidade e segurança em ambientes de produção. Neste módulo você irá integrar o projeto com pipelines de integração e entrega contínua (CI/CD) e preparar a infraestrutura em nuvem (AWS, Azure ou outra) para o uso de certificados automatizados.
+
+## Estrutura e conexões do módulo
+
+| Capítulo | Conteúdo | Conexões principais |
+| --- | --- | --- |
+| [01 · Visão estratégica da jornada em nuvem](./01_visao_estrategica.md) | Panorama inspirador da jornada para cloud e CI/CD, lembrando os aprendizados dos módulos 2 a 7. | Reforça a linha do tempo que culmina no `modulo10_projeto_final` e estabelece a cultura de automação. |
+| [02 · Pipelines do cartório digital](./02_pipelines_cartorio.md) | Criação de pipelines GitHub Actions com estágios de build, segurança, assinatura e deploy. | Consome scripts de assinatura do `modulo7_assinatura_artefatos` e requisitos de conformidade do `modulo5_regulatorio`. |
+| [03 · Infraestrutura como código na nuvem](./03_iac_nuvem.md) | Provisionamento de ambientes com Terraform e automação de certificados em load balancers. | Conecta-se com automações do `modulo4_automacao` e governança de chaves do `modulo6_kms_hsm`. |
+| [04 · Observabilidade e alertas em pipelines cloud](./04_observabilidade_alertas.md) | Instrumentação de métricas e alertas para pipelines e certificados. | Complementa as práticas de `modulo9_observabilidade` e garante continuidade operacional. |
+| [05 · Desafio final do módulo](./05_desafio_final.md) | Exercício integrador que entrega uma release completa com monitoramento e documentação. | Prepara para consolidar tudo no `modulo10_projeto_final`. |
+
+Assim, este módulo atua como ponte entre a fundação técnica construída nos módulos anteriores e a materialização completa no projeto final.
 
 ## Objetivos de aprendizagem
 


### PR DESCRIPTION
## Summary
- add five inspirational chapters covering visão estratégica, pipelines, IaC, observabilidade e desafio final do módulo de cloud e CI/CD
- incluir exemplos guiados com GitHub Actions, Terraform e Grafana conectando-se ao projeto do cartório digital
- atualizar o README do módulo com a estrutura dos novos capítulos e ligações aos módulos anteriores e ao projeto final

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e565a13b8483288434380516eaef53