### PR TITLE
Adicionar capítulos orientadores ao projeto final do módulo 10

### DIFF
--- a/modulo10_projeto_final/01_visao_integrada.md
+++ b/modulo10_projeto_final/01_visao_integrada.md
@@ -1,0 +1,33 @@
+# Visão Integrada do Cartório Digital
+
+## Problema vivido pelo cartório digital
+
+Mesmo após a construção dos módulos anteriores, o cartório digital ainda sofre com uma visão fragmentada: certificados, assinaturas, infraestrutura e compliance convivem em silos, dificultando auditorias, escalabilidade e entrega contínua de valor ao cidadão.
+
+## Conexão inspiradora com os módulos anteriores
+
+Lembre-se da jornada: no **Módulo 1** estruturamos os fundamentos regulatórios, no **Módulo 2** forjamos uma PKI confiável, avançando para **TLS e mTLS** no Módulo 3, automação no **Módulo 4**, governança regulatória no **Módulo 5**, proteção de chaves no **Módulo 6**, assinatura de artefatos no **Módulo 7**, pipelines de nuvem no **Módulo 8** e observabilidade no **Módulo 9**. Agora, unimos tudo para entregar uma operação coesa, resiliente e auditável.
+
+## Ferramentas e comandos como solução
+
+- **Mapa de integração dos serviços críticos**
+  ```mermaid
+  graph TD
+    A[Frontend do Cartório] -->|TLS 1.3| B[API mTLS]
+    B -->|Assinatura Digital| C[Serviço de Assinaturas]
+    B -->|Registro| D[Ledger Imutável]
+    D -->|Transparência| E[Monitoria de Logs]
+    C -->|Carimbo do Tempo| F[Time Stamping Authority]
+  ```
+- **Verificação unificada dos certificados ativos**
+  ```bash
+  step ca certificates list --authority cartorio-ca
+  ```
+- **Checklist de readiness das integrações**
+  ```bash
+  kubectl get deployments -n cartorio && kubectl get certificaterequests.cert-manager.io -n cartorio
+  ```
+- **Auditoria de conformidade cruzada**
+  ```bash
+  opa eval --data policies/ --input evidencias/cartorio.json "data.cartorio.conformidade"
+  ```

--- a/modulo10_projeto_final/02_trilhas_entrega_cartorio.md
+++ b/modulo10_projeto_final/02_trilhas_entrega_cartorio.md
@@ -1,0 +1,36 @@
+# Trilhas de Entrega do Cartório Digital
+
+## Problema vivido pelo cartório digital
+
+O time precisa orquestrar uma entrega final impecável, mas enfrenta atrasos na publicação de novas features, ambientes inconsistentes e falta de confiança no processo de deploy.
+
+## Conexão inspiradora com os módulos anteriores
+
+A infraestrutura automatizada do **Módulo 4**, os pipelines seguros do **Módulo 8** e a governança regulatória do **Módulo 5** foram construídos justamente para garantir que a última milha seja previsível. Some a isso as práticas de proteção de chaves do **Módulo 6** e as assinaturas qualificadas do **Módulo 7** para assegurar que cada release seja legítima e rastreável.
+
+## Ferramentas e comandos como solução
+
+- **Trilha de deploy final em múltiplos estágios**
+  ```bash
+  terraform workspace select producao
+  terraform apply -auto-approve
+  helm upgrade --install cartorio charts/cartorio -n cartorio --values values/producao.yaml
+  ```
+- **Pipeline de promoção assistida**
+  ```yaml
+  stages:
+    - build
+    - assinatura
+    - deploy
+  deploy:
+    script:
+      - flux reconcile kustomization cartorio-prod --with-source
+  ```
+- **Checklist de pré-deploy automatizado**
+  ```bash
+  ./scripts/verificar-compliance.sh && ./scripts/testes-finais.sh
+  ```
+- **Registro do fluxo de assinatura de release**
+  ```bash
+  cosign sign --key kms://cartorio-kms chave-deploy@latest
+  ```

--- a/modulo10_projeto_final/03_governanca_operacao.md
+++ b/modulo10_projeto_final/03_governanca_operacao.md
@@ -1,0 +1,30 @@
+# Governança e Operação Contínua
+
+## Problema vivido pelo cartório digital
+
+Após o go-live, o cartório digital percebe que a confiabilidade operacional não acompanha as exigências legais: faltam evidências consolidadas, os alertas são ruidosos e a auditoria tem dificuldade em seguir o trilho de decisões.
+
+## Conexão inspiradora com os módulos anteriores
+
+Os requisitos regulatórios e de auditoria do **Módulo 5** e a observabilidade estruturada no **Módulo 9** mostraram que governança não é um departamento, mas sim uma prática contínua. Some os controles de identidade do **Módulo 3** e as políticas de certificação do **Módulo 2** para construir um painel que fale a linguagem do auditor e da operação.
+
+## Ferramentas e comandos como solução
+
+- **Exemplo prático de observabilidade inspiradora**
+  ```bash
+  tempo query '{job="cartorio-api"}' --time-range=1h
+  grafana dashboards import dashboards/cartorio-operacao.json
+  ```
+- **Fluxo de auditoria de assinaturas e selos**
+  ```bash
+  step certificate inspect --format json artefatos/assinaturas/certidão-*.pem | jq '.extensions'
+  ```
+- **Política de rotação de segredos e evidência de execução**
+  ```bash
+  vault write -force secret/data/cartorio/api
+  vault audit enable file file_path=/var/log/vault/auditoria.log
+  ```
+- **Gestão de incidentes com livro-razão imutável**
+  ```bash
+  ledger-cli --file registros/incidentes.ledger balanco incidentes
+  ```

--- a/modulo10_projeto_final/04_orquestracao_tecnologia.md
+++ b/modulo10_projeto_final/04_orquestracao_tecnologia.md
@@ -1,0 +1,34 @@
+# Orquestração Tecnológica do Cartório Digital
+
+## Problema vivido pelo cartório digital
+
+A plataforma enfrenta fricções entre times de aplicação, segurança e infraestrutura: pipelines concorrentes, configurações duplicadas e ausência de um maestro tecnológico que alinhe infraestrutura como código, segurança e compliance.
+
+## Conexão inspiradora com os módulos anteriores
+
+Os manifestos automatizados do **Módulo 4**, as políticas de chaves do **Módulo 6** e o pipeline cloud-native do **Módulo 8** compõem a base para um arranjo harmonioso. O aprendizado em assinatura de artefatos do **Módulo 7** e as métricas do **Módulo 9** garantem rastreabilidade e feedback contínuo.
+
+## Ferramentas e comandos como solução
+
+- **Orquestração central com GitOps**
+  ```bash
+  flux bootstrap github \
+    --owner cartorio-digital \
+    --repository infraestrutura \
+    --branch main \
+    --path clusters/producao
+  ```
+- **Automação de políticas com Open Policy Agent**
+  ```bash
+  conftest test manifests/ --policy policies/
+  ```
+- **Coordenação de secrets e HSM virtual**
+  ```bash
+  kmsctl sync --config configs/kms/producao.yaml
+  softhsm2-util --show-slots
+  ```
+- **Plano de capacidade e escalonamento**
+  ```bash
+  kubectl describe hpa cartorio-api -n cartorio
+  k6 run testes/performance/producao.js
+  ```

--- a/modulo10_projeto_final/05_apresentacao_execucao.md
+++ b/modulo10_projeto_final/05_apresentacao_execucao.md
@@ -1,0 +1,31 @@
+# Apresentação Executiva e Handover
+
+## Problema vivido pelo cartório digital
+
+A direção e os órgãos reguladores exigem clareza sobre o valor entregue, mas o time técnico encontra dificuldade em traduzir a solução para uma linguagem estratégica e em organizar o handover para operação contínua.
+
+## Conexão inspiradora com os módulos anteriores
+
+Cada módulo construiu não só componentes técnicos, mas histórias de transformação: da visão regulatória do **Módulo 1**, passando pela confiança criptográfica dos **Módulos 2 e 3**, até a automação do **Módulo 4**, a aderência normativa do **Módulo 5**, a custódia de chaves do **Módulo 6**, a assinatura centrada no cidadão do **Módulo 7**, a entrega contínua do **Módulo 8** e a transparência do **Módulo 9**. Use essa narrativa para inspirar stakeholders e preparar a transição.
+
+## Ferramentas e comandos como solução
+
+- **Roteiro de apresentação executiva**
+  ```markdown
+  1. Visão estratégica: missão, dores solucionadas, indicadores.
+  2. Jornada técnica: módulos, integrações e ganhos.
+  3. Demonstração guiada: fluxo de emissão e assinatura.
+  4. Próximos passos: escalabilidade, novos serviços e governança.
+  ```
+- **Handover estruturado para operação**
+  ```bash
+  ./scripts/gerar-playbook-operacao.sh --saida handover/cartorio-final.pdf
+  ```
+- **Catálogo de serviços e responsabilidades**
+  ```bash
+  backstage-cli generate docs --entity cartorio-digital --format pdf
+  ```
+- **Registro de lições aprendidas**
+  ```bash
+  retrotool export --board cartorio-final --output lições-aprendidas.md
+  ```

--- a/modulo10_projeto_final/README.md
+++ b/modulo10_projeto_final/README.md
@@ -1,7 +1,20 @@
-
 # Módulo 10 – Projeto Final Integrador
 
 Chegou a hora de consolidar todos os conhecimentos adquiridos e entregar um **cartório digital funcional**. Este módulo reúne todos os componentes desenvolvidos ao longo do curso em um único projeto integrado, pronto para demonstração e validação.
+
+## Como navegar pelo projeto final
+
+Este módulo foi organizado como uma jornada guiada que conecta os aprendizados dos módulos 1 a 9 e mostra como cada artefato converge para a entrega final. Recomendamos a leitura sequencial dos capítulos abaixo, sempre revisitanto os módulos anteriores quando surgirem dúvidas ou oportunidades de aprofundamento.
+
+### Sumário dos capítulos
+
+1. [Visão Integrada do Cartório Digital](01_visao_integrada.md) – alinhe a narrativa do problema aos blocos técnicos e jurídicos que sustentam a plataforma.
+2. [Trilhas de Entrega do Cartório Digital](02_trilhas_entrega_cartorio.md) – planeje e execute o deploy final com confiança e rastreabilidade.
+3. [Governança e Operação Contínua](03_governanca_operacao.md) – mantenha a conformidade viva por meio de observabilidade e auditorias contínuas.
+4. [Orquestração Tecnológica do Cartório Digital](04_orquestracao_tecnologia.md) – conecte automação, segurança e infraestrutura em um fluxo único.
+5. [Apresentação Executiva e Handover](05_apresentacao_execucao.md) – prepare a narrativa de valor e organize a transição para a operação.
+
+Cada capítulo apresenta o problema real enfrentado pelo cartório digital, relembra os módulos anteriores que apoiam a solução e lista ferramentas e comandos recomendados. Use-os como roteiro para montar sua demonstração final, produzir as evidências de conformidade e construir um handover inspirador.
 
 ## Objetivos
 


### PR DESCRIPTION
## Summary
- adicionar cinco capítulos temáticos ao projeto final para contextualizar problemas e soluções do cartório digital
- incluir exemplos práticos de deploy, assinatura, observabilidade e handover com comandos sugeridos
- atualizar o README do módulo 10 com sumário navegável e orientação integrada ao restante do curso

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5683afd208328b14a3fda6f0a1d97