### PR TITLE
Adicionar capítulos inspiradores ao módulo de observabilidade

### DIFF
--- a/modulo9_observabilidade/01_visao_observabilidade_cartorio.md
+++ b/modulo9_observabilidade/01_visao_observabilidade_cartorio.md
@@ -1,0 +1,22 @@
+# Visão Inspiradora de Observabilidade para o Cartório Digital
+
+O cartório digital vinha celebrando cada ato eletrônico como conquista coletiva, mas a equipe sentia ansiedade diante da possibilidade de qualquer certificado ser questionado em público sem prova clara de confiança. Foi nesse momento que compreendemos que **observabilidade** seria nossa bússola para transformar insegurança em narrativa de transparência.
+
+## Conceito: Transparência como Pilar
+Antes de executar qualquer comando, reforçamos a base conceitual: observabilidade em PKI é a capacidade de transformar emissões de certificados em evidências verificáveis por qualquer cidadão. Ao publicar certificados nos **Certificate Transparency (CT) logs**, garantimos que a história do cartório esteja aberta para auditoria contínua.
+
+## Conectando ao Projeto Principal
+No módulo 2 construímos a AC interna e no módulo 3 ativamos TLS para os serviços do cartório. Agora, precisamos garantir que essa cadeia de confiança seja visível publicamente. Observabilidade fecha o ciclo ao permitir que auditores validem cada emissão do repositório `cartorio-digital`.
+
+## Exemplo Guiado: Consultando CT Logs via crt.sh
+Já conscientes da importância dos CT logs, utilizamos o `crt.sh` para verificar se o certificado do domínio `cartorio.digital.gov.br` está presente. Só depois de compreender o propósito (dar transparência) recorremos ao comando:
+
+```bash
+curl "https://crt.sh/?q=cartorio.digital.gov.br&output=json" | jq '.[0] | {log: .issuer.name, data_emissao: .not_before}'
+```
+
+- **O que observamos:** o campo `log` mostra em qual log público o certificado foi registrado.
+- **Como isso inspira a equipe:** cada linha recebida confirma que os atos do cartório deixam pegadas verificáveis.
+
+## Próximos Passos
+Compreender CT logs é o primeiro passo. Os capítulos seguintes exploram como monitorar revogação, métricas e alertas, transformando observabilidade em cultura diária.

--- a/modulo9_observabilidade/02_transparencia_certificados.md
+++ b/modulo9_observabilidade/02_transparencia_certificados.md
@@ -1,0 +1,28 @@
+# Transparência dos Certificados como Vitrine Pública
+
+O cartório digital enfrentou críticas quando um cidadão questionou a autenticidade de uma certidão eletrônica emitida meses atrás. Percebemos que, sem visibilidade clara de cada emissão, a confiança seria sempre vulnerável. Decidimos transformar essa tensão em oportunidade: tornar os certificados rastreáveis do começo ao fim.
+
+## Conceito: Linhagem de Certificados
+Transparência significa oferecer **linhagem completa** para cada certificado emitido pela Autoridade Certificadora criada no módulo 2. Antes de qualquer consulta técnica, revisitamos o conceito de que toda AC confiável precisa disponibilizar registros públicos de emissão e revogação.
+
+## Passo a Passo Conectado ao Projeto
+1. **Revisar as emissões anteriores:** os certificados emitidos no diretório `modulo2_pkicertificados/output/` precisam ser publicados em CT logs e catalogados.
+2. **Registrar os hashes:** catalogar os hashes SHA-256 das certidões garante rastreabilidade para cada documento digital.
+
+Somente depois de compreendermos esses dois objetivos partimos para os comandos.
+
+```bash
+for cert in modulo2_pkicertificados/output/*.crt; do
+  echo "Registrando $(basename "$cert")"
+  openssl x509 -in "$cert" -noout -fingerprint -sha256
+  curl -X POST https://ct.googleapis.com/logs/argon2024/ct/v1/add-chain \
+    -H 'Content-Type: application/json' \
+    -d @<(python scripts/build_ct_payload.py "$cert")
+done
+```
+
+- **Por que funciona:** primeiro calculamos o fingerprint para documentar internamente, depois submetemos ao log Argon usando o payload gerado no script do projeto.
+- **Resultado inspirado:** cada submissão é uma declaração pública de integridade que reforça a reputação do cartório digital.
+
+## Fechando o Loop
+Ao tornar cada certificado verificável, fortalecemos a confiança que sustenta os serviços eletrônicos criados nos módulos anteriores. Transparência não é custo; é a vitrine que mostra ao cidadão que o cartório digital está sempre aberto.

--- a/modulo9_observabilidade/03_ocsp_monitoramento.md
+++ b/modulo9_observabilidade/03_ocsp_monitoramento.md
@@ -1,0 +1,38 @@
+# OCSP Monitorado: Do Medo de Revogação à Confiança Contínua
+
+Durante uma auditoria de rotina, descobrimos que a consulta OCSP do cartório digital estava respondendo de forma intermitente. A equipe temia que, em um momento crítico, uma certidão pudesse ser considerada inválida. Transformamos esse receio em motivação para implementar um monitoramento contínuo e inspirador.
+
+## Conceito: OCSP e Confirmação de Validade
+Antes de aplicar qualquer comando, revisitamos o propósito do **Online Certificate Status Protocol (OCSP)**: fornecer a terceiros a garantia de que um certificado não foi revogado. Quando ativamos **OCSP stapling** no módulo 3, demos um salto em desempenho; agora precisamos garantir disponibilidade e latência adequadas.
+
+## Passos Conectados ao Cartório Digital
+1. **Configurar OCSP stapling** no servidor web oficial (`nginx` presente em `modulo3_tls_mtls/config/nginx.conf`).
+2. **Monitorar respostas** com métricas claras para nosso Prometheus interno (configurado no módulo 8).
+
+Somente após compreender esses pilares partimos para a configuração prática.
+
+```nginx
+# Trecho do nginx.conf com OCSP stapling
+ssl_stapling on;
+ssl_stapling_verify on;
+resolver 8.8.8.8 1.1.1.1 valid=300s;
+resolver_timeout 5s;
+ssl_trusted_certificate /etc/nginx/certs/chain.pem;
+```
+
+Esse trecho garante que o servidor inclua a resposta OCSP assinada a cada handshake TLS, reduzindo chamadas feitas pelos clientes.
+
+## Exemplo Guiado de Monitoramento com Prometheus
+Com o conceito em mente, coletamos métricas sobre a latência da consulta OCSP usando um exporter dedicado no namespace `observabilidade`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cartorio-digital/scripts/main/ocsp_exporter.yml \
+  | tee /etc/prometheus/file_sd/ocsp_exporter.yml
+systemctl reload prometheus
+```
+
+- **Por que executamos:** o arquivo de descoberta adiciona o endpoint `https://ocsp.cartorio.digital.gov.br/status` ao Prometheus já utilizado no módulo 8.
+- **Qual insight geramos:** o dashboard mostra tempo de resposta e códigos de erro, garantindo ação pró-ativa caso o stapling falhe.
+
+## Cultura de Vigilância
+Monitorar OCSP é mais do que evitar incidentes; é reforçar diariamente a promessa do cartório digital de manter validade incontestável para cada certificado.

--- a/modulo9_observabilidade/04_metricas_grafana.md
+++ b/modulo9_observabilidade/04_metricas_grafana.md
@@ -1,0 +1,33 @@
+# Métricas no Grafana: Tornando a Saúde do Cartório Visível
+
+Quando o time percebeu que a expiração de um certificado estava próxima e ninguém havia sido alertado, entendemos que métricas isoladas não bastam. Precisávamos contar a história do cartório digital por painéis claros e inspiradores.
+
+## Conceito: Observabilidade Quantitativa
+Antes de construir qualquer dashboard, revisitamos o conceito de **observabilidade quantitativa**: transformar eventos invisíveis em indicadores contínuos. A coleta iniciada no módulo 8 com Prometheus precisa agora ser traduzida em visualizações que conectem segurança e operações.
+
+## Integração com o Projeto
+- **Fonte de dados:** Prometheus já configurado para coletar métricas de certificados e OCSP.
+- **Indicadores-chave:** tempo até expiração (`cert_expiry_seconds`), latência de OCSP (`ocsp_latency_seconds`) e contagem de alertas (`cartorio_tls_alerts_total`).
+
+## Exemplo Guiado: Construindo o Painel no Grafana
+Com o conceito em mente, abrimos o Grafana e importamos um JSON de dashboard preparado pela equipe. Só depois de entender que cada gráfico representa um ponto da jornada do certificado executamos o comando de provisionamento.
+
+```bash
+cat <<'DASH' > /etc/grafana/provisioning/dashboards/cartorio-observabilidade.json
+{
+  "title": "Cartório Digital – Observabilidade PKI",
+  "panels": [
+    {"type": "gauge", "title": "Dias até expiração", "targets": [{"expr": "(cert_expiry_seconds/86400)"}]},
+    {"type": "graph", "title": "Latência do OCSP", "targets": [{"expr": "ocsp_latency_seconds"}]},
+    {"type": "stat", "title": "Alertas ativos", "targets": [{"expr": "cartorio_tls_alerts_total"}]}
+  ]
+}
+DASH
+systemctl restart grafana-server
+```
+
+- **Mensagem transmitida pelo painel:** cada colaborador vê, em tempo real, quanto tempo temos até a expiração e se existe algum alerta pendente.
+- **Impacto cultural:** dashboards tornam-se rituais diários, reforçando a missão de entregar atos notariais totalmente confiáveis.
+
+## Visualizações como História Viva
+Esse painel fecha o ciclo dos módulos anteriores mostrando, de forma tangível, como nossas decisões de PKI, automação e infraestrutura garantem confiança contínua.

--- a/modulo9_observabilidade/05_desafio_operacional.md
+++ b/modulo9_observabilidade/05_desafio_operacional.md
@@ -1,0 +1,46 @@
+# Desafio Operacional: Orquestrando Alertas que Mobilizam o Cartório
+
+Após conquistar a confiança do público, enfrentamos um novo desafio: como garantir que, em plena madrugada, alguém responda a um alerta de expiração crítica? Essa inquietação nos levou a propor um exercício coletivo que consolida tudo o que aprendemos.
+
+## Conceito: Alertas Orientados a Ação
+Antes de configurar qualquer notificação, reforçamos o conceito de que **alertas efetivos são aqueles que disparam ações concretas**. Não basta enviar e-mails; precisamos de playbooks que conectem o aviso à resposta.
+
+## Conexão com os Módulos Anteriores
+- Do módulo 2 trazemos o inventário de certificados.
+- Do módulo 3 herdamos a infraestrutura TLS com OCSP stapling.
+- Do módulo 8 utilizamos o pipeline de CI/CD na nuvem para aplicar configurações automaticamente.
+
+## Exercício Guiado: Criando Alertas no Alertmanager
+Com a filosofia alinhada, configuramos um alerta que dispara quando restarem menos de 15 dias para um certificado expirar e outro quando a latência do OCSP exceder 2 segundos.
+
+```bash
+cat <<'ALERTS' > /etc/prometheus/alert_rules/cartorio_certificados.yml
+groups:
+  - name: cartorio-certificados
+    rules:
+      - alert: CertificadoProximoExpirar
+        expr: (cert_expiry_seconds / 86400) < 15
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Certificado próximo de expirar"
+          description: "{{ $labels.instance }} expira em {{ $value | printf "%.1f" }} dias"
+      - alert: LatenciaOCSPElevada
+        expr: ocsp_latency_seconds > 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Latência do OCSP acima do esperado"
+          description: "{{ $labels.instance }} respondeu em {{ $value }} segundos"
+ALERTS
+systemctl reload prometheus
+```
+
+## Plano de Ação Inspirador
+1. **Alertmanager envia mensagem** para o canal `#plantao-cartorio` no Slack.
+2. **Runbook automatizado** (pipeline do módulo 8) aplica renovação ou reinicia o serviço com OCSP.
+3. **Debrief matinal** registra aprendizados e ajusta SLOs.
+
+Ao final, transformamos alerta em oportunidade de superação, garantindo que o cartório digital esteja pronto para servir com excelência ininterrupta.

--- a/modulo9_observabilidade/README.md
+++ b/modulo9_observabilidade/README.md
@@ -1,6 +1,13 @@
 # Módulo 9 – Observabilidade e Logs de Transparência
 
-Para garantir a confiabilidade do cartório digital, é necessário monitorar certificados, verificar status de revogação e publicar eventos relevantes.  Este módulo aborda técnicas de observabilidade, como o uso de **Certificate Transparency (CT) logs**, OCSP stapling e métricas de expiração.
+A jornada do cartório digital percorreu fundamentos, certificação, automação e nuvem. Este módulo fecha o ciclo mostrando como observabilidade transforma todas essas escolhas em confiança contínua. Ao monitorar certificados, validar revogações e contar histórias por métricas visíveis, o cidadão percebe que cada ato notarial permanece íntegro mesmo após a emissão.
+
+## Sumário Inspirador
+- [Visão Inspiradora de Observabilidade para o Cartório Digital](01_visao_observabilidade_cartorio.md) – apresenta o problema de transparência pública e mostra CT logs como solução.
+- [Transparência dos Certificados como Vitrine Pública](02_transparencia_certificados.md) – guia a publicação de emissões em logs e cataloga fingerprints do módulo 2.
+- [OCSP Monitorado: Do Medo de Revogação à Confiança Contínua](03_ocsp_monitoramento.md) – revisita o OCSP stapling do módulo 3 e conecta a métricas coletadas no módulo 8.
+- [Métricas no Grafana: Tornando a Saúde do Cartório Visível](04_metricas_grafana.md) – transforma métricas em dashboards que contam a história operacional.
+- [Desafio Operacional: Orquestrando Alertas que Mobilizam o Cartório](05_desafio_operacional.md) – propõe alertas e runbooks que garantem resposta imediata.
 
 ## Objetivos de aprendizagem
 


### PR DESCRIPTION
## Summary
- adicionar cinco capítulos temáticos no módulo 9 para guiar transparência, OCSP, métricas e alertas do cartório digital
- atualizar o README do módulo com um sumário que conecta a jornada dos módulos anteriores à observabilidade

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e567e356f8832883439365a6d467d1