### PR TITLE
Refine documentação dos hooks de automação

### DIFF
--- a/modulo4_automacao/05_automacao_hooks.md
+++ b/modulo4_automacao/05_automacao_hooks.md
@@ -5,19 +5,19 @@ Os certificados Let's Encrypt e de outras autoridades ACME geralmente têm valid
 
 ## Cron ou systemd timer
 
-O Certbot instala um timer systemd por padrão nas distribuições modernas. Para visualizar:
+Quando ha risco de interrupcao porque o certificado expirou sem que o timer rodasse, confira se o timer do Certbot esta ativo:
 
 ```bash
 sudo systemctl list-timers certbot.timer
 ```
 
-Se não estiver habilitado, ative:
+Caso identifique que o timer nao esta habilitado e queira evitar uma nova parada inesperada, execute:
 
 ```bash
 sudo systemctl enable --now certbot.timer
 ```
 
-Isso executara `certbot renew` duas vezes ao dia. Voce tambem pode agendar renovacoes via cron:
+Isso executara `certbot renew` duas vezes ao dia. Quando o ambiente nao possui systemd ou voce precisa garantir a renovacao em um servidor legado, evite expiracao configurando um cron manual:
 
 ```bash
 0 */12 * * * root certbot renew --quiet
@@ -31,16 +31,14 @@ Durante o comando `renew`, voce pode especificar scripts que serao executados:
 - `--post-hook`: executa apos cada tentativa de renovacao, independentemente de sucesso.
 - `--deploy-hook`: executa apenas quando um certificado e efetivamente renovado.
 
-Exemplo para recarregar o Nginx somente quando um certificado mudou:
+Imagine que o Nginx precisa carregar o certificado novo sem derrubar o servico; nesse cenario, utilize um deploy hook para recarregar o processo apenas quando houver mudanca:
 
 ```bash
 sudo certbot renew \
   --deploy-hook "systemctl reload nginx"
 ```
 
-Voce
-pode escrever um script `deploy_cert.sh` mais complexo:
-Crie um script `deploy_cert.sh` que copia os arquivos renovados para o local usado pelo seu serviço e reinicia ou reload o serviço. Por exemplo:
+Voce pode escrever um script `deploy_cert.sh` mais completo. Esse script garante que o portal do cartorio digital permaneça acessivel, porque ele copia os certificados para o diretorio monitorado pelo Nginx e realiza apenas um `reload`, preservando as conexoes existentes enquanto aplica o novo material criptografico. Crie o arquivo com o conteudo a seguir:
 
     #!/bin/bash
     # Este script sera chamado automaticamente pelo certbot com variaveis de ambiente
@@ -50,9 +48,9 @@ Crie um script `deploy_cert.sh` que copia os arquivos renovados para o local usa
     systemctl reload nginx
     echo "Certificado aplicado com sucesso!"
 
-Salve-o em `/etc/letsencrypt/renewal-hooks/deploy/deploy_cert.sh` e torne-o executável (`chmod +x deploy_cert.sh`). O certbot executara esse script apenas quando um novo certificado for emitido.
+Salve-o em `/etc/letsencrypt/renewal-hooks/deploy/deploy_cert.sh` e torne-o executavel (`chmod +x deploy_cert.sh`). O certbot executara esse script apenas quando um novo certificado for emitido, mantendo o portal disponivel durante todo o processo.
 
-Para ambientes AWS, voce pode substituir os comandos de copia por chamadas da AWS CLI para importar o certificado no ACM:
+Quando o objetivo e substituir rapidamente um certificado expirado no AWS Certificate Manager (ACM) e liberar o acesso para balanceadores gerenciados, troque as copias locais por uma importacao via AWS CLI:
 
     aws acm import-certificate \
       --certificate fileb://"$RENEWED_LINEAGE/cert.pem" \
@@ -62,7 +60,13 @@ Para ambientes AWS, voce pode substituir os comandos de copia por chamadas da AW
 
 ### Testando e depurando
 
-Utilize `sudo certbot renew --dry-run` para testar a renovacao sem de fato emitir um novo certificado. Verifique se os scripts de hooks sao executados conforme esperado e ajuste permissoes ou caminhos se necessario.
+Para evitar que renovacoes silenciosas falhem sem alerta — problema comum quando hooks quebram ou permissoes mudam — faca um ensaio com o modo de teste e confirme o comportamento dos scripts:
+
+```bash
+sudo certbot renew --dry-run
+```
+
+Verifique se os hooks sao executados conforme esperado e ajuste permissoes ou caminhos se necessario.
 
 ### Atividades
 


### PR DESCRIPTION
## Summary
- contextualize cada comando com cenários de interrupção, recarga sem downtime e importação no ACM
- descreva como o script deploy_cert.sh mantém a disponibilidade do portal durante a renovação
- destaque o uso de --dry-run para evitar falhas silenciosas de renovação

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56c63bcf08328bb3c938c447e42ba