### PR TITLE
Refina orientações de análise de certificados qualificados

### DIFF
--- a/modulo5_regulatorio/04_certificados_qualificados_e_avancados.md
+++ b/modulo5_regulatorio/04_certificados_qualificados_e_avancados.md
@@ -34,5 +34,9 @@ No módulo 7 você aprendeu a diferença entre assinaturas qualificada e avanç
 
 ### Atividades
 
-1. Analise um certificado de assinatura qualificada (pode ser um PFX de token ou QSCD europeu) com `openssl x509 -text`. Identifique as extensões `qcStatements` e `policyIdentifier`.
+O cartório digital precisa comprovar que o token QSCD utilizado pelos tabeliães atende a todos os requisitos legais. Para confirmar que o certificado embarcado no dispositivo declara conformidade com QSCD e política qualificada, será necessário inspecionar seu conteúdo detalhadamente; isso nos leva a utilizar o comando `openssl x509 -text`.
+
+1. Para responder ao desafio acima, execute `openssl x509 -text` no certificado de assinatura qualificada (pode ser um PFX de token ou QSCD europeu) e identifique as extensões `qcStatements` e `policyIdentifier`.
 2. Consulte a DPC de uma AC qualificada (QTSP) e verifique os procedimentos exigidos para emissão. Compare com a DPC de uma AC padrão.
+
+Ao dominar essa análise de certificados, você alimenta as decisões de arquitetura e conformidade do projeto final, garantindo que os componentes escolhidos atendam aos requisitos regulatórios desde o início.


### PR DESCRIPTION
## Summary
- adiciona contexto regulatório motivando o uso do comando `openssl x509 -text`
- esclarece que a execução do comando responde ao desafio proposto
- reforça como a análise de certificados apoia decisões do projeto final

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e56cf49afc8328b46de8a0988089e7