### PR TITLE
Document manual rotation plan for RSA signing CMKs

### DIFF
--- a/modulo6_kms_hsm/03_implementacao_kms_cartorio.md
+++ b/modulo6_kms_hsm/03_implementacao_kms_cartorio.md
@@ -33,10 +33,10 @@ para garantir segregação e rastreabilidade.
 ### Provisionamento com Terraform
 ```hcl
 resource "aws_kms_key" "assinatura_cartorio" {
-  description             = "Chave KMS para assinatura do Cartório Digital"
-  key_usage               = "SIGN_VERIFY"
+  description              = "Chave KMS para assinatura do Cartório Digital"
+  key_usage                = "SIGN_VERIFY"
   customer_master_key_spec = "RSA_2048"
-  deletion_window_in_days = 30
+  deletion_window_in_days  = 30
 }
 
 resource "aws_kms_alias" "assinatura_cartorio" {
@@ -44,6 +44,13 @@ resource "aws_kms_alias" "assinatura_cartorio" {
   target_key_id = aws_kms_key.assinatura_cartorio.key_id
 }
 ```
-As chaves assimétricas de assinatura (`KeyUsage = "SIGN_VERIFY"`) com `customer_master_key_spec = "RSA_2048"` **não** suportam rotação automática; por isso, a opção `enable_key_rotation` não aparece no recurso acima.
 
-> **Planejamento de rotação manual:** para renovar chaves de assinatura, crie uma nova CMK com as mesmas características, atualize a aplicação/alias para apontar para a nova chave, valide as novas assinaturas e, somente após a transição completa, desative e agende a exclusão da chave antiga. Registre o processo e mantenha evidências de teste para auditoria.
+CMKs usadas para **assinatura** (`KeyUsage = "SIGN_VERIFY"`) com `customer_master_key_spec = "RSA_2048"`
+não suportam rotação automática pelo KMS. Para o Cartório Digital, isso significa que a rotação deve ser
+planejada e executada manualmente, obedecendo às janelas de mudança e aos controles de conformidade
+estabelecidos para os selos digitais.
+
+> **Nota sobre rotação manual planejada:** crie uma nova CMK com a mesma configuração, atualize aliases
+> e políticas para apontar para a nova chave, valide a aplicação e os fluxos de assinatura, e somente após
+> a transição controlada desative e agende a exclusão da CMK anterior. Registre os passos, evidências de
+> teste e aprovações para sustentar auditorias futuras.

--- a/modulo6_kms_hsm/05_praticas_auditoria_rotacao.md
+++ b/modulo6_kms_hsm/05_praticas_auditoria_rotacao.md
@@ -19,7 +19,15 @@ if key_metadata["KeyUsage"] == "ENCRYPT_DECRYPT":
 ```
 
 ### Chaves assimétricas (SIGN_VERIFY)
-- Não existe rotação automática; mantenha um processo manual documentado.
-- Planeje a criação antecipada de uma nova CMK e a troca controlada do alias/ARN nas aplicações.
-- Valide as novas assinaturas antes de desativar a chave antiga e arquive as evidências de teste para auditoria.
-- Após a migração, desabilite a chave anterior e agende sua exclusão conforme as políticas de retenção.
+- A aplicação de assinatura do Cartório Digital utiliza CMKs `RSA_2048`, que não suportam a API de rotação automática.
+- Execute rotação manual coordenada: abra uma mudança, crie uma nova CMK com a mesma política, republique os aliases
+  (`alias/cartorio-assinatura`), ajuste permissões de IAM e valide a emissão dos selos digitais na nova chave.
+- Registre em ata os testes de assinatura/verificação, o cutover do alias e a desativação programada da chave anterior.
+- Agende a exclusão somente após a confirmação da equipe jurídica e arquive as evidências de auditoria.
+```python
+key_metadata = kms.describe_key(KeyId=key_id)["KeyMetadata"]
+if key_metadata["KeyUsage"] == "SIGN_VERIFY" and key_metadata["KeySpec"].startswith("RSA_"):
+    raise RuntimeError(
+        "Rotação automática indisponível para CMKs de assinatura RSA; siga o runbook de rotação manual."
+    )
+```


### PR DESCRIPTION
## Summary
- clarify que CMKs RSA de assinatura não suportam rotação automática e exigem planejamento manual
- acrescentar nota com o passo a passo recomendado para rotação manual no Cartório Digital
- atualizar práticas e script de auditoria diferenciando rotação automática de chaves simétricas e o runbook manual para RSA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56d7634508328bbbc636725e9f706