### PR TITLE
Atualiza seção introdutória do módulo de cloud

### DIFF
--- a/modulo8_cloud_cicd/01_visao_estrategica.md
+++ b/modulo8_cloud_cicd/01_visao_estrategica.md
@@ -22,7 +22,7 @@ Antes de automatizar, revisitamos como os módulos anteriores alimentam esta fas
 
 Somente depois de alinhar esses conceitos é que criamos o primeiro fluxo automatizado.
 
-## Exemplo inspirador com GitHub Actions
+## Introdução
 
 ```yaml
 # .github/workflows/cartorio-ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm test
 ```
 
-Essa base permite que cada mudança de código percorra uma trilha confiável, reforçando o compromisso do cartório digital com entregas frequentes e seguras.
+Essa introdução permite que cada mudança de código percorra uma trilha confiável, reforçando o compromisso do cartório digital com entregas frequentes e seguras.
 
 ## Conexão com o projeto final
 


### PR DESCRIPTION
## Summary
- renomeia a seção "Exemplo Inspirador" para "Introdução" na visão estratégica de cloud
- ajusta o parágrafo adjacente para manter a coerência com o novo título

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e58c9fc3448328a8fc1fcd2b147f64