### PR TITLE
Add incremental cartório digital projects for modules 1-10

### DIFF
--- a/modulo10_projeto_final/projeto/README.md
+++ b/modulo10_projeto_final/projeto/README.md
@@ -1,0 +1,43 @@
+# Módulo 10 &mdash; Projeto Final Integrado
+
+O projeto final consolida todos os módulos anteriores em uma única aplicação full-stack, permitindo acompanhar o ciclo de vida completo de certificação digital: cadastro, emissão, automação ACME, integração com KMS/HSM, assinatura de artefatos, pipelines e observabilidade.
+
+## Funcionalidades
+
+- **Cadastro e Compliance:** validação de documentos e auditoria das emissões.
+- **PKI completa:** certificados de cliente, servidor, revogação e simulação mTLS.
+- **Automação ACME:** ordens e desafios automáticos para emissões TLS.
+- **Integração KMS/HSM:** emissão de credenciais com chaves protegidas e assinatura via alias.
+- **Assinatura de artefatos:** certificados de code signing e registros de assinaturas.
+- **Pipeline CI/CD:** execução de builds, assinatura e deploy simulados com governança.
+- **Observabilidade:** métricas, traces e logs agregados em uma API única.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Sirva o frontend integrado:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+Acesse `http://localhost:3000` para interagir com todos os fluxos.
+
+## Validação sugerida
+
+1. Cadastre um cidadão, emita certificado de cliente e valide o compliance.
+2. Gere um certificado de servidor e realize um handshake mTLS usando os números de série retornados.
+3. Crie uma ordem ACME, valide o token e inspecione as métricas geradas.
+4. Emita credenciais protegidas pelo KMS, assine um payload e consulte as chaves disponíveis.
+5. Execute um pipeline CI/CD e observe a criação automática de credenciais e artefatos assinados.
+6. Consulte `/observability/snapshot` e `/observability/metrics/prometheus` para monitorar o sistema.
+
+Cada etapa registra métricas e logs na camada de observabilidade, fornecendo rastreabilidade ponta a ponta.

--- a/modulo10_projeto_final/projeto/backend/acme.py
+++ b/modulo10_projeto_final/projeto/backend/acme.py
@@ -1,0 +1,55 @@
+"""Simplified ACME order management for the project."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from crypto import CertificateAuthority, IssuedCertificate
+
+
+@dataclass
+class AcmeOrder:
+    order_id: str
+    domain: str
+    token: str
+    created_at: datetime
+    status: str = "pending"
+    certificate_serial: int | None = None
+
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) > self.created_at + timedelta(minutes=15)
+
+
+class AcmeDirectory:
+    def __init__(self, ca: CertificateAuthority) -> None:
+        self.ca = ca
+        self._orders: Dict[str, AcmeOrder] = {}
+
+    def new_order(self, domain: str, token: str) -> AcmeOrder:
+        order = AcmeOrder(
+            order_id=f"order-{len(self._orders)+1}",
+            domain=domain,
+            token=token,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._orders[order.order_id] = order
+        return order
+
+    def complete_challenge(self, order_id: str, provided_token: str) -> IssuedCertificate:
+        order = self._orders[order_id]
+        if order.is_expired():
+            order.status = "expired"
+            raise ValueError("Order expired")
+        if order.token != provided_token:
+            raise ValueError("Invalid challenge token")
+        certificate = self.ca.issue_server_certificate(order.domain)
+        order.status = "valid"
+        order.certificate_serial = certificate.serial_number
+        return certificate
+
+    def get_order(self, order_id: str) -> AcmeOrder:
+        return self._orders[order_id]
+
+    def list_orders(self) -> Dict[str, AcmeOrder]:
+        return dict(self._orders)

--- a/modulo10_projeto_final/projeto/backend/code_signing.py
+++ b/modulo10_projeto_final/projeto/backend/code_signing.py
@@ -1,0 +1,83 @@
+"""Support for code-signing certificates."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from kms import MockKMS
+
+
+@dataclass
+class SigningCredential:
+    serial_number: int
+    subject: str
+    certificate_pem: str
+    key_alias: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+
+
+class CodeSigningCA:
+    def __init__(self, common_name: str, kms: MockKMS) -> None:
+        self.kms = kms
+        self._root_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._root_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._root_key, hashes.SHA256())
+        )
+        self._issued: Dict[int, SigningCredential] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def issue_signing_certificate(self, common_name: str) -> SigningCredential:
+        alias = f"code-sign/{len(self._issued)+1}"
+        key_metadata = self.kms.create_key(alias)
+        now = datetime.now(timezone.utc)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)]))
+            .issuer_name(self._certificate.subject)
+            .public_key(
+                serialization.load_pem_public_key(key_metadata.public_key_pem.encode())
+            )
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=180))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CODE_SIGNING]),
+                critical=False,
+            )
+        ).sign(self._root_key, hashes.SHA256())
+
+        credential = SigningCredential(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            certificate_pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            key_alias=alias,
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+        )
+        self._issued[certificate.serial_number] = credential
+        return credential
+
+    def list_credentials(self) -> Dict[int, SigningCredential]:
+        return dict(self._issued)

--- a/modulo10_projeto_final/projeto/backend/compliance.py
+++ b/modulo10_projeto_final/projeto/backend/compliance.py
@@ -1,0 +1,50 @@
+"""Simple compliance checks used to emulate requisitos regulatórios."""
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List
+
+from crypto import IssuedCertificate
+
+
+@dataclass
+class CitizenRecord:
+    name: str
+    email: str
+    document_type: str
+    document_id: str
+
+
+@dataclass
+class ComplianceResult:
+    rule_id: str
+    passed: bool
+    detail: str
+
+
+class ComplianceEngine:
+    allowed_documents = {"RG", "CPF", "CNH"}
+
+    def evaluate(self, citizen: CitizenRecord, certificate: IssuedCertificate) -> List[ComplianceResult]:
+        results: List[ComplianceResult] = []
+        results.append(self._check_document_type(citizen))
+        results.append(self._check_document_length(citizen))
+        results.append(self._check_certificate_validity(certificate))
+        return results
+
+    def _check_document_type(self, citizen: CitizenRecord) -> ComplianceResult:
+        passed = citizen.document_type in self.allowed_documents
+        detail = (
+            "Documento permitido" if passed else "Tipo de documento não reconhecido"
+        )
+        return ComplianceResult("DOC_TYPE", passed, detail)
+
+    def _check_document_length(self, citizen: CitizenRecord) -> ComplianceResult:
+        passed = len(citizen.document_id) >= 5
+        detail = "Documento válido" if passed else "Documento muito curto"
+        return ComplianceResult("DOC_LENGTH", passed, detail)
+
+    def _check_certificate_validity(self, certificate: IssuedCertificate) -> ComplianceResult:
+        remaining = certificate.not_valid_after - datetime.now(timezone.utc)
+        passed = remaining.days >= 30
+        detail = f"Validade restante: {remaining.days} dias"
+        return ComplianceResult("CERT_VALIDITY", passed, detail)

--- a/modulo10_projeto_final/projeto/backend/crypto.py
+++ b/modulo10_projeto_final/projeto/backend/crypto.py
@@ -1,0 +1,119 @@
+"""PKI helper tailored for TLS/mTLS experiments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+@dataclass
+class IssuedCertificate:
+    serial_number: int
+    subject: str
+    pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+    revoked: bool = False
+    purpose: str = "generic"
+
+
+class CertificateAuthority:
+    def __init__(self, common_name: str) -> None:
+        self.common_name = common_name
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCertificate] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def _issue(self, builder: x509.CertificateBuilder, purpose: str) -> IssuedCertificate:
+        certificate = builder.sign(self._key, hashes.SHA256())
+        issued = IssuedCertificate(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+            purpose=purpose,
+        )
+        self._issued[issued.serial_number] = issued
+        return issued
+
+    def issue_client_certificate(self, common_name: str, email: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "client")
+
+    def issue_server_certificate(self, hostname: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=90))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "server")
+
+    def revoke(self, serial_number: int) -> Optional[IssuedCertificate]:
+        cert = self._issued.get(serial_number)
+        if cert:
+            cert.revoked = True
+        return cert
+
+    def get(self, serial_number: int) -> Optional[IssuedCertificate]:
+        return self._issued.get(serial_number)
+
+    def list_all(self) -> Dict[int, IssuedCertificate]:
+        return dict(self._issued)

--- a/modulo10_projeto_final/projeto/backend/kms.py
+++ b/modulo10_projeto_final/projeto/backend/kms.py
@@ -1,0 +1,45 @@
+"""Mock KMS/HSM integration layer."""
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Dict
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+@dataclass
+class KeyMetadata:
+    alias: str
+    public_key_pem: str
+
+
+class MockKMS:
+    def __init__(self) -> None:
+        self._keys: Dict[str, rsa.RSAPrivateKey] = {}
+
+    def create_key(self, alias: str) -> KeyMetadata:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._keys[alias] = private_key
+        public_pem = (
+            private_key.public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode()
+        )
+        return KeyMetadata(alias=alias, public_key_pem=public_pem)
+
+    def sign(self, alias: str, data: bytes) -> str:
+        key = self._keys[alias]
+        signature = key.sign(
+            data,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode()
+
+    def list_keys(self) -> Dict[str, int]:
+        return {alias: key.key_size for alias, key in self._keys.items()}

--- a/modulo10_projeto_final/projeto/backend/kms_ca.py
+++ b/modulo10_projeto_final/projeto/backend/kms_ca.py
@@ -1,0 +1,89 @@
+"""Certificate issuance backed by a mock KMS."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from kms import MockKMS
+
+
+@dataclass
+class IssuedCredential:
+    serial_number: int
+    subject: str
+    certificate_pem: str
+    key_alias: str
+    public_key_pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+
+
+class KmsBackedCA:
+    def __init__(self, common_name: str, kms: MockKMS) -> None:
+        self.kms = kms
+        self.common_name = common_name
+        self._root_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._root_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._root_key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCredential] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def issue_certificate(self, common_name: str, email: str) -> IssuedCredential:
+        alias = f"identity/{len(self._issued)+1}"
+        key_metadata = self.kms.create_key(alias)
+        now = datetime.now(timezone.utc)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(
+                serialization.load_pem_public_key(key_metadata.public_key_pem.encode())
+            )
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+        ).sign(self._root_key, hashes.SHA256())
+
+        credential = IssuedCredential(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            certificate_pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            key_alias=key_metadata.alias,
+            public_key_pem=key_metadata.public_key_pem,
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+        )
+        self._issued[credential.serial_number] = credential
+        return credential
+
+    def list_credentials(self) -> Dict[int, IssuedCredential]:
+        return dict(self._issued)

--- a/modulo10_projeto_final/projeto/backend/main.py
+++ b/modulo10_projeto_final/projeto/backend/main.py
@@ -1,0 +1,428 @@
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+
+from acme import AcmeDirectory, AcmeOrder
+from code_signing import CodeSigningCA, SigningCredential
+from compliance import CitizenRecord, ComplianceEngine
+from crypto import CertificateAuthority, IssuedCertificate
+from kms import MockKMS
+from kms_ca import IssuedCredential, KmsBackedCA
+from observability import ObservabilityHub
+from pipeline import PipelineExecution, PipelineOrchestrator
+from signing import ArtifactSigner, SignedArtifact
+from tls import validate_mutual_tls
+
+
+class CitizenInput(BaseModel):
+    name: str
+    email: EmailStr
+    document_type: str
+    document_id: str
+
+
+class ClientCertificateRequest(BaseModel):
+    email: EmailStr
+    common_name: str
+
+
+class ServerCertificateRequest(BaseModel):
+    hostname: str
+
+
+class HandshakeRequest(BaseModel):
+    server_serial: int
+    client_serial: int
+
+
+class AcmeOrderRequest(BaseModel):
+    domain: str
+
+
+class AcmeCompleteRequest(BaseModel):
+    token: str
+
+
+class CredentialRequest(BaseModel):
+    email: EmailStr
+    common_name: str
+
+
+class SignCredentialRequest(BaseModel):
+    common_name: str
+
+
+class ArtifactRequest(BaseModel):
+    artifact_id: str
+    key_alias: str
+    payload: str
+    description: str | None = None
+
+
+class PipelineRequest(BaseModel):
+    application: str
+    environment: str
+    payload: str
+
+
+class MetricRequest(BaseModel):
+    name: str
+    value: float
+    labels: Dict[str, str] | None = None
+
+
+class TraceRequest(BaseModel):
+    span_id: str
+    name: str
+    duration_ms: float
+    attributes: Dict[str, str] | None = None
+
+
+class LogRequest(BaseModel):
+    level: str
+    message: str
+    context: Dict[str, str] | None = None
+
+
+app = FastAPI(title="Cartório Digital - Projeto Final")
+
+citizens: Dict[str, CitizenRecord] = {}
+compliance_engine = ComplianceEngine()
+audit_log: List[Dict[str, object]] = []
+
+primary_ca = CertificateAuthority("Cartorio Digital Root CA")
+acme_directory = AcmeDirectory(primary_ca)
+
+kms = MockKMS()
+kms_ca = KmsBackedCA("Cartorio Digital KMS CA", kms)
+code_sign_ca = CodeSigningCA("Cartorio Digital Code Signing", kms)
+artifact_signer = ArtifactSigner(kms)
+pipeline_orchestrator = PipelineOrchestrator(kms, code_sign_ca, artifact_signer)
+observability = ObservabilityHub()
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "modules": "1-10"}
+
+
+@app.post("/citizens")
+def register_citizen(citizen: CitizenInput) -> Dict[str, str]:
+    record = CitizenRecord(**citizen.model_dump())
+    citizens[citizen.email] = record
+    observability.record_log("INFO", "Citizen registered", email=citizen.email)
+    return {"message": "Citizen registered", "email": citizen.email}
+
+
+@app.get("/citizens")
+def list_citizens() -> Dict[str, Dict[str, str]]:
+    return {"citizens": {email: record.__dict__ for email, record in citizens.items()}}
+
+
+@app.post("/certificates/client")
+def issue_client_certificate(request: ClientCertificateRequest) -> Dict[str, object]:
+    citizen = citizens.get(request.email)
+    if not citizen:
+        raise HTTPException(status_code=404, detail="Citizen not registered")
+    certificate = primary_ca.issue_client_certificate(request.common_name, request.email)
+    results = compliance_engine.evaluate(citizen, certificate)
+    audit_entry = {
+        "email": citizen.email,
+        "results": [result.__dict__ for result in results],
+        "certificate_serial": certificate.serial_number,
+    }
+    audit_log.append(audit_entry)
+    if not all(result.passed for result in results):
+        observability.record_log("WARN", "Compliance failure", email=citizen.email)
+        raise HTTPException(status_code=400, detail=audit_entry)
+    observability.record_metric("certificates_issued_total", 1, type="client")
+    return {
+        "certificate": _serialize_certificate(certificate),
+        "compliance": audit_entry,
+    }
+
+
+@app.post("/certificates/server")
+def issue_server_certificate(request: ServerCertificateRequest) -> Dict[str, str]:
+    certificate = primary_ca.issue_server_certificate(request.hostname)
+    observability.record_metric("certificates_issued_total", 1, type="server")
+    return _serialize_certificate(certificate)
+
+
+@app.get("/certificates")
+def list_certificates() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "certificates": {
+            str(serial): _serialize_certificate(cert)
+            for serial, cert in primary_ca.list_all().items()
+        }
+    }
+
+
+@app.post("/certificates/{serial_number}/revoke")
+def revoke_certificate(serial_number: int) -> Dict[str, str]:
+    cert = primary_ca.revoke(serial_number)
+    if not cert:
+        raise HTTPException(status_code=404, detail="Certificate not found")
+    observability.record_log("INFO", "Certificate revoked", serial=str(serial_number))
+    return _serialize_certificate(cert)
+
+
+@app.post("/tls/handshake")
+def simulate_handshake(request: HandshakeRequest) -> Dict[str, str]:
+    if not validate_mutual_tls(primary_ca, request.server_serial, request.client_serial):
+        observability.record_log("ERROR", "mTLS failure")
+        raise HTTPException(status_code=400, detail="mTLS validation failed")
+    observability.record_metric("mtls_handshakes_total", 1, status="success")
+    return {"message": "mTLS negotiation succeeded"}
+
+
+@app.post("/acme/orders")
+def new_acme_order(request: AcmeOrderRequest) -> Dict[str, str]:
+    order = acme_directory.new_order(request.domain, token=_generate_token(request.domain))
+    observability.record_metric("acme_orders_total", 1, status="pending")
+    return _serialize_order(order)
+
+
+@app.post("/acme/orders/{order_id}/complete")
+def complete_acme_order(order_id: str, completion: AcmeCompleteRequest) -> Dict[str, object]:
+    try:
+        certificate = acme_directory.complete_challenge(order_id, completion.token)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Order not found") from exc
+    except ValueError as exc:
+        observability.record_log("ERROR", "ACME challenge failed", order=order_id)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    observability.record_metric("acme_orders_total", 1, status="valid")
+    return {"certificate": _serialize_certificate(certificate)}
+
+
+@app.get("/acme/orders")
+def list_acme_orders() -> Dict[str, Dict[str, str]]:
+    return {
+        "orders": {
+            order_id: _serialize_order(order)
+            for order_id, order in acme_directory.list_orders().items()
+        }
+    }
+
+
+@app.post("/kms/credentials")
+def issue_kms_credential(request: CredentialRequest) -> Dict[str, str]:
+    credential = kms_ca.issue_certificate(request.common_name, request.email)
+    observability.record_metric("kms_credentials_total", 1, email=request.email)
+    return _serialize_credential(credential)
+
+
+@app.get("/kms/credentials")
+def list_kms_credentials() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "credentials": {
+            str(serial): _serialize_credential(credential)
+            for serial, credential in kms_ca.list_credentials().items()
+        }
+    }
+
+
+@app.get("/kms/keys")
+def list_keys() -> Dict[str, Dict[str, int]]:
+    return {"keys": kms.list_keys()}
+
+
+@app.post("/signing/credentials")
+def issue_signing_credential(request: SignCredentialRequest) -> Dict[str, str]:
+    credential = code_sign_ca.issue_signing_certificate(request.common_name)
+    observability.record_metric("signing_credentials_total", 1)
+    return _serialize_signing_credential(credential)
+
+
+@app.get("/signing/credentials")
+def list_signing_credentials() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "credentials": {
+            str(serial): _serialize_signing_credential(credential)
+            for serial, credential in code_sign_ca.list_credentials().items()
+        }
+    }
+
+
+@app.post("/signing/artifacts")
+def sign_artifact(request: ArtifactRequest) -> Dict[str, str]:
+    if request.key_alias not in kms.list_keys():
+        raise HTTPException(status_code=404, detail="Key alias not found")
+    artifact = artifact_signer.sign(
+        request.artifact_id,
+        request.key_alias,
+        request.payload.encode(),
+        {"description": request.description or ""},
+    )
+    observability.record_metric("artifacts_signed_total", 1)
+    return _serialize_artifact(artifact)
+
+
+@app.get("/signing/artifacts")
+def list_signed_artifacts() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "artifacts": {
+            artifact_id: _serialize_artifact(artifact)
+            for artifact_id, artifact in artifact_signer.list_signed().items()
+        }
+    }
+
+
+@app.post("/pipelines")
+def trigger_pipeline(request: PipelineRequest) -> Dict[str, object]:
+    execution = pipeline_orchestrator.run_pipeline(
+        request.application, request.environment, request.payload
+    )
+    observability.record_metric("pipelines_executed_total", 1, environment=request.environment)
+    return _serialize_pipeline(execution)
+
+
+@app.get("/pipelines")
+def list_pipelines() -> Dict[str, Dict[str, object]]:
+    return {
+        "pipelines": {
+            execution.pipeline_id: _serialize_pipeline(execution)
+            for execution in pipeline_orchestrator.list_executions().values()
+        }
+    }
+
+
+@app.post("/observability/metrics")
+def record_metric_endpoint(request: MetricRequest) -> Dict[str, str]:
+    labels = request.labels or {}
+    sample = observability.record_metric(request.name, request.value, **labels)
+    return {
+        "name": sample.name,
+        "value": sample.value,
+        "labels": sample.labels,
+        "recorded_at": sample.recorded_at.isoformat(),
+    }
+
+
+@app.post("/observability/traces")
+def record_trace_endpoint(request: TraceRequest) -> Dict[str, str]:
+    attributes = request.attributes or {}
+    span = observability.record_trace(request.span_id, request.name, request.duration_ms, **attributes)
+    return {
+        "span_id": span.span_id,
+        "name": span.name,
+        "duration_ms": span.duration_ms,
+        "attributes": span.attributes,
+        "timestamp": span.timestamp.isoformat(),
+    }
+
+
+@app.post("/observability/logs")
+def record_log_endpoint(request: LogRequest) -> Dict[str, str]:
+    context = request.context or {}
+    log = observability.record_log(request.level, request.message, **context)
+    return {
+        "level": log.level,
+        "message": log.message,
+        "timestamp": log.timestamp.isoformat(),
+        "context": log.context,
+    }
+
+
+@app.get("/observability/snapshot")
+def snapshot() -> Dict[str, object]:
+    return observability.snapshot()
+
+
+@app.get("/observability/metrics/prometheus")
+def prometheus() -> str:
+    return observability.render_prometheus()
+
+
+@app.get("/audit")
+def list_audit() -> Dict[str, List[Dict[str, object]]]:
+    return {"entries": audit_log}
+
+
+def _generate_token(domain: str) -> str:
+    return f"token-{abs(hash(domain)) % 10_000_000}"
+
+
+def _serialize_certificate(cert: IssuedCertificate) -> Dict[str, str]:
+    return {
+        "serial_number": str(cert.serial_number),
+        "subject": cert.subject,
+        "pem": cert.pem,
+        "not_valid_before": cert.not_valid_before.isoformat(),
+        "not_valid_after": cert.not_valid_after.isoformat(),
+        "revoked": str(cert.revoked).lower(),
+        "purpose": cert.purpose,
+    }
+
+
+def _serialize_order(order: AcmeOrder) -> Dict[str, str]:
+    return {
+        "order_id": order.order_id,
+        "domain": order.domain,
+        "token": order.token,
+        "status": order.status,
+        "certificate_serial": str(order.certificate_serial) if order.certificate_serial else None,
+    }
+
+
+def _serialize_credential(credential: IssuedCredential) -> Dict[str, str]:
+    return {
+        "serial_number": str(credential.serial_number),
+        "subject": credential.subject,
+        "certificate": credential.certificate_pem,
+        "key_alias": credential.key_alias,
+        "public_key": credential.public_key_pem,
+        "not_valid_before": credential.not_valid_before.isoformat(),
+        "not_valid_after": credential.not_valid_after.isoformat(),
+    }
+
+
+def _serialize_signing_credential(credential: SigningCredential) -> Dict[str, str]:
+    return {
+        "serial_number": str(credential.serial_number),
+        "subject": credential.subject,
+        "certificate": credential.certificate_pem,
+        "key_alias": credential.key_alias,
+        "not_valid_before": credential.not_valid_before.isoformat(),
+        "not_valid_after": credential.not_valid_after.isoformat(),
+    }
+
+
+def _serialize_artifact(artifact: SignedArtifact) -> Dict[str, str]:
+    return {
+        "artifact_id": artifact.artifact_id,
+        "digest": artifact.digest,
+        "signature": artifact.signature,
+        "key_alias": artifact.key_alias,
+        "signed_at": artifact.signed_at.isoformat(),
+        "metadata": artifact.metadata,
+    }
+
+
+def _serialize_pipeline(execution: PipelineExecution) -> Dict[str, object]:
+    return {
+        "pipeline_id": execution.pipeline_id,
+        "application": execution.application,
+        "environment": execution.environment,
+        "credential": {
+            "serial_number": str(execution.credential.serial_number),
+            "key_alias": execution.credential.key_alias,
+        },
+        "artifact": {
+            "id": execution.artifact.artifact_id,
+            "digest": execution.artifact.digest,
+            "signature": execution.artifact.signature,
+        },
+        "steps": [
+            {
+                "name": step.name,
+                "status": step.status,
+                "detail": step.detail,
+                "completed_at": step.completed_at.isoformat(),
+            }
+            for step in execution.steps
+        ],
+    }

--- a/modulo10_projeto_final/projeto/backend/observability.py
+++ b/modulo10_projeto_final/projeto/backend/observability.py
@@ -1,0 +1,104 @@
+"""In-memory observability toolkit for the lab."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List
+
+
+@dataclass
+class MetricSample:
+    name: str
+    value: float
+    labels: Dict[str, str]
+    recorded_at: datetime
+
+
+@dataclass
+class TraceSpan:
+    span_id: str
+    name: str
+    duration_ms: float
+    attributes: Dict[str, str]
+    timestamp: datetime
+
+
+@dataclass
+class LogEntry:
+    level: str
+    message: str
+    timestamp: datetime
+    context: Dict[str, str]
+
+
+class ObservabilityHub:
+    def __init__(self) -> None:
+        self.metrics: List[MetricSample] = []
+        self.traces: List[TraceSpan] = []
+        self.logs: List[LogEntry] = []
+
+    def record_metric(self, name: str, value: float, **labels: str) -> MetricSample:
+        sample = MetricSample(name=name, value=value, labels=labels, recorded_at=datetime.now(timezone.utc))
+        self.metrics.append(sample)
+        return sample
+
+    def record_trace(self, span_id: str, name: str, duration_ms: float, **attributes: str) -> TraceSpan:
+        span = TraceSpan(
+            span_id=span_id,
+            name=name,
+            duration_ms=duration_ms,
+            attributes=attributes,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.traces.append(span)
+        return span
+
+    def record_log(self, level: str, message: str, **context: str) -> LogEntry:
+        log = LogEntry(
+            level=level,
+            message=message,
+            timestamp=datetime.now(timezone.utc),
+            context=context,
+        )
+        self.logs.append(log)
+        return log
+
+    def snapshot(self) -> Dict[str, List[Dict[str, str]]]:
+        return {
+            "metrics": [
+                {
+                    "name": sample.name,
+                    "value": sample.value,
+                    "labels": sample.labels,
+                    "recorded_at": sample.recorded_at.isoformat(),
+                }
+                for sample in self.metrics
+            ],
+            "traces": [
+                {
+                    "span_id": span.span_id,
+                    "name": span.name,
+                    "duration_ms": span.duration_ms,
+                    "attributes": span.attributes,
+                    "timestamp": span.timestamp.isoformat(),
+                }
+                for span in self.traces
+            ],
+            "logs": [
+                {
+                    "level": log.level,
+                    "message": log.message,
+                    "timestamp": log.timestamp.isoformat(),
+                    "context": log.context,
+                }
+                for log in self.logs
+            ],
+        }
+
+    def render_prometheus(self) -> str:
+        lines = []
+        for sample in self.metrics:
+            label_parts = ",".join(f"{key}='{value}'" for key, value in sample.labels.items())
+            label_block = f"{{{label_parts}}}" if label_parts else ""
+            lines.append(f"{sample.name}{label_block} {sample.value}")
+        return "\n".join(lines)

--- a/modulo10_projeto_final/projeto/backend/pipeline.py
+++ b/modulo10_projeto_final/projeto/backend/pipeline.py
@@ -1,0 +1,94 @@
+"""CI/CD orchestration utilities."""
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List
+
+from crypto import CodeSigningCA, SigningCredential
+from kms import MockKMS
+from signing import ArtifactSigner, SignedArtifact
+
+
+@dataclass
+class PipelineStep:
+    name: str
+    status: str
+    detail: str
+    completed_at: datetime
+
+
+@dataclass
+class PipelineExecution:
+    pipeline_id: str
+    application: str
+    environment: str
+    credential: SigningCredential
+    artifact: SignedArtifact
+    steps: List[PipelineStep] = field(default_factory=list)
+
+
+class PipelineOrchestrator:
+    def __init__(self, kms: MockKMS, ca: CodeSigningCA, signer: ArtifactSigner) -> None:
+        self.kms = kms
+        self.ca = ca
+        self.signer = signer
+        self._executions: Dict[str, PipelineExecution] = {}
+
+    def run_pipeline(self, application: str, environment: str, payload: str) -> PipelineExecution:
+        pipeline_id = f"pipeline-{len(self._executions)+1}"
+        credential = self.ca.issue_signing_certificate(f"{application}-{environment}")
+        steps: List[PipelineStep] = []
+
+        # Build step
+        digest = hashlib.sha256(payload.encode()).digest()
+        steps.append(
+            PipelineStep(
+                name="build",
+                status="success",
+                detail=f"SHA256={base64.b64encode(digest).decode()}",
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        # Sign step
+        artifact = self.signer.sign(
+            artifact_id=f"{application}:{environment}:{pipeline_id}",
+            key_alias=credential.key_alias,
+            payload=payload.encode(),
+            metadata={"environment": environment},
+        )
+        steps.append(
+            PipelineStep(
+                name="sign",
+                status="success",
+                detail=f"Signed with {credential.key_alias}",
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        # Deploy step
+        steps.append(
+            PipelineStep(
+                name="deploy",
+                status="success",
+                detail=f"Deployed to {environment}",
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        execution = PipelineExecution(
+            pipeline_id=pipeline_id,
+            application=application,
+            environment=environment,
+            credential=credential,
+            artifact=artifact,
+            steps=steps,
+        )
+        self._executions[pipeline_id] = execution
+        return execution
+
+    def list_executions(self) -> Dict[str, PipelineExecution]:
+        return dict(self._executions)

--- a/modulo10_projeto_final/projeto/backend/requirements.txt
+++ b/modulo10_projeto_final/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo10_projeto_final/projeto/backend/signing.py
+++ b/modulo10_projeto_final/projeto/backend/signing.py
@@ -1,0 +1,43 @@
+"""Artifact signing workflow using the mock KMS."""
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict
+
+from kms import MockKMS
+
+
+@dataclass
+class SignedArtifact:
+    artifact_id: str
+    digest: str
+    signature: str
+    key_alias: str
+    signed_at: datetime
+    metadata: Dict[str, str]
+
+
+class ArtifactSigner:
+    def __init__(self, kms: MockKMS) -> None:
+        self.kms = kms
+        self._signed: Dict[str, SignedArtifact] = {}
+
+    def sign(self, artifact_id: str, key_alias: str, payload: bytes, metadata: Dict[str, str]) -> SignedArtifact:
+        digest_bytes = hashlib.sha256(payload).digest()
+        signature = self.kms.sign(key_alias, digest_bytes)
+        artifact = SignedArtifact(
+            artifact_id=artifact_id,
+            digest=base64.b64encode(digest_bytes).decode(),
+            signature=signature,
+            key_alias=key_alias,
+            signed_at=datetime.now(timezone.utc),
+            metadata=metadata,
+        )
+        self._signed[artifact_id] = artifact
+        return artifact
+
+    def list_signed(self) -> Dict[str, SignedArtifact]:
+        return dict(self._signed)

--- a/modulo10_projeto_final/projeto/backend/tls.py
+++ b/modulo10_projeto_final/projeto/backend/tls.py
@@ -1,0 +1,27 @@
+"""TLS helper functions."""
+from datetime import datetime, timezone
+
+from cryptography import x509
+
+from crypto import CertificateAuthority
+
+
+def validate_mutual_tls(ca: CertificateAuthority, server_serial: int, client_serial: int) -> bool:
+    """Validate that both certificates exist, are not revoked and are valid for mTLS."""
+    server = ca.get(server_serial)
+    client = ca.get(client_serial)
+    if not server or not client:
+        return False
+    if server.revoked or client.revoked:
+        return False
+    now = datetime.now(timezone.utc)
+    if server.not_valid_after < now or client.not_valid_after < now:
+        return False
+
+    server_cert = x509.load_pem_x509_certificate(server.pem.encode())
+    client_cert = x509.load_pem_x509_certificate(client.pem.encode())
+    eku_server = server_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    eku_client = client_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    has_server_auth = any(oid.dotted_string == "1.3.6.1.5.5.7.3.1" for oid in eku_server.value)
+    has_client_auth = any(oid.dotted_string == "1.3.6.1.5.5.7.3.2" for oid in eku_client.value)
+    return has_server_auth and has_client_auth

--- a/modulo10_projeto_final/projeto/frontend/index.html
+++ b/modulo10_projeto_final/projeto/frontend/index.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Projeto Final</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+        background: #f9fafb;
+      }
+      h1 {
+        margin-bottom: 0.5rem;
+      }
+      section {
+        background: #ffffff;
+        border-radius: 8px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      }
+      form {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button,
+      textarea,
+      select {
+        padding: 0.6rem;
+        border-radius: 6px;
+        border: 1px solid #d1d5db;
+        font-size: 0.95rem;
+      }
+      button {
+        background: #2563eb;
+        color: #fff;
+        border: none;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #1d4ed8;
+      }
+      textarea {
+        min-height: 120px;
+      }
+      pre {
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 1rem;
+        border-radius: 6px;
+        overflow: auto;
+        max-height: 280px;
+        font-size: 0.9rem;
+      }
+      .columns {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Projeto Final</h1>
+    <p>
+      Aplicação integrada demonstrando cadastro de cidadãos, emissão de certificados, automação ACME, KMS/HSM, assinatura de artefatos, pipelines e observabilidade.
+    </p>
+
+    <section>
+      <h2>Cadastro e Compliance</h2>
+      <form id="citizen-form">
+        <input type="text" id="citizen-name" placeholder="Nome" required />
+        <input type="email" id="citizen-email" placeholder="E-mail" required />
+        <select id="citizen-doc-type">
+          <option value="RG">RG</option>
+          <option value="CPF">CPF</option>
+          <option value="CNH">CNH</option>
+        </select>
+        <input type="text" id="citizen-doc-id" placeholder="Documento" required />
+        <button type="submit">Registrar cidadão</button>
+      </form>
+      <div class="columns">
+        <pre id="citizens"></pre>
+        <pre id="audit"></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>PKI & TLS</h2>
+      <form id="client-cert-form">
+        <input type="email" id="client-email" placeholder="E-mail cadastrado" required />
+        <input type="text" id="client-cn" placeholder="Common Name" required />
+        <button type="submit">Emitir certificado de cliente</button>
+      </form>
+      <form id="server-cert-form">
+        <input type="text" id="server-host" placeholder="Hostname" required />
+        <button type="submit">Emitir certificado de servidor</button>
+      </form>
+      <form id="handshake-form">
+        <input type="number" id="server-serial" placeholder="Serial servidor" required />
+        <input type="number" id="client-serial" placeholder="Serial cliente" required />
+        <button type="submit">Validar mTLS</button>
+      </form>
+      <div class="columns">
+        <pre id="certificates"></pre>
+        <pre id="handshake"></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Automação ACME</h2>
+      <form id="acme-form">
+        <input type="text" id="acme-domain" placeholder="dominio.exemplo" required />
+        <button type="submit">Criar ordem</button>
+      </form>
+      <form id="acme-complete-form">
+        <input type="text" id="acme-order-id" placeholder="ID da ordem" required />
+        <input type="text" id="acme-token" placeholder="Token" required />
+        <button type="submit">Completar desafio</button>
+      </form>
+      <pre id="acme"></pre>
+    </section>
+
+    <section>
+      <h2>KMS / HSM</h2>
+      <form id="kms-form">
+        <input type="email" id="kms-email" placeholder="E-mail" required />
+        <input type="text" id="kms-cn" placeholder="Common Name" required />
+        <button type="submit">Emitir credencial protegida</button>
+      </form>
+      <div class="columns">
+        <pre id="kms-credentials"></pre>
+        <pre id="kms-keys"></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Assinatura de Artefatos</h2>
+      <form id="sign-credential-form">
+        <input type="text" id="sign-cn" placeholder="Common Name" required />
+        <button type="submit">Emitir credencial de code signing</button>
+      </form>
+      <form id="artifact-form">
+        <input type="text" id="artifact-id" placeholder="ID do artefato" required />
+        <input type="text" id="artifact-alias" placeholder="Alias da chave" required />
+        <textarea id="artifact-payload" placeholder="Conteúdo" required></textarea>
+        <input type="text" id="artifact-desc" placeholder="Descrição" />
+        <button type="submit">Assinar artefato</button>
+      </form>
+      <div class="columns">
+        <pre id="signing-credentials"></pre>
+        <pre id="artifacts"></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Pipeline CI/CD</h2>
+      <form id="pipeline-form">
+        <input type="text" id="pipeline-app" placeholder="Aplicação" required />
+        <input type="text" id="pipeline-env" placeholder="Ambiente" required />
+        <textarea id="pipeline-payload" placeholder="Manifesto/artefato" required></textarea>
+        <button type="submit">Executar pipeline</button>
+      </form>
+      <pre id="pipelines"></pre>
+    </section>
+
+    <section>
+      <h2>Observabilidade</h2>
+      <form id="metric-form">
+        <input type="text" id="metric-name" placeholder="Nome da métrica" required />
+        <input type="number" step="0.01" id="metric-value" placeholder="Valor" required />
+        <textarea id="metric-labels" placeholder='Labels JSON'></textarea>
+        <button type="submit">Registrar métrica</button>
+      </form>
+      <div class="columns">
+        <pre id="observability-snapshot"></pre>
+        <pre id="observability-prom"></pre>
+      </div>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function fetchJson(url) {
+        const response = await fetch(url);
+        return response.json();
+      }
+
+      function toJsonTextarea(value) {
+        if (!value) return {};
+        try {
+          return JSON.parse(value);
+        } catch (error) {
+          alert("JSON inválido: " + error.message);
+          throw error;
+        }
+      }
+
+      async function refreshCitizens() {
+        const data = await fetchJson(`${API_BASE}/citizens`);
+        document.getElementById("citizens").textContent = JSON.stringify(
+          data.citizens,
+          null,
+          2
+        );
+        const audit = await fetchJson(`${API_BASE}/audit`);
+        document.getElementById("audit").textContent = JSON.stringify(
+          audit.entries,
+          null,
+          2
+        );
+      }
+
+      async function refreshCertificates() {
+        const data = await fetchJson(`${API_BASE}/certificates`);
+        document.getElementById("certificates").textContent = JSON.stringify(
+          data.certificates,
+          null,
+          2
+        );
+      }
+
+      async function refreshAcme() {
+        const data = await fetchJson(`${API_BASE}/acme/orders`);
+        document.getElementById("acme").textContent = JSON.stringify(
+          data.orders,
+          null,
+          2
+        );
+      }
+
+      async function refreshKms() {
+        const credentials = await fetchJson(`${API_BASE}/kms/credentials`);
+        document.getElementById("kms-credentials").textContent = JSON.stringify(
+          credentials.credentials,
+          null,
+          2
+        );
+        const keys = await fetchJson(`${API_BASE}/kms/keys`);
+        document.getElementById("kms-keys").textContent = JSON.stringify(
+          keys.keys,
+          null,
+          2
+        );
+      }
+
+      async function refreshSigning() {
+        const credentials = await fetchJson(`${API_BASE}/signing/credentials`);
+        document.getElementById("signing-credentials").textContent = JSON.stringify(
+          credentials.credentials,
+          null,
+          2
+        );
+        const artifacts = await fetchJson(`${API_BASE}/signing/artifacts`);
+        document.getElementById("artifacts").textContent = JSON.stringify(
+          artifacts.artifacts,
+          null,
+          2
+        );
+      }
+
+      async function refreshPipelines() {
+        const data = await fetchJson(`${API_BASE}/pipelines`);
+        document.getElementById("pipelines").textContent = JSON.stringify(
+          data.pipelines,
+          null,
+          2
+        );
+      }
+
+      async function refreshObservability() {
+        const snapshot = await fetchJson(`${API_BASE}/observability/snapshot`);
+        document.getElementById("observability-snapshot").textContent = JSON.stringify(
+          snapshot,
+          null,
+          2
+        );
+        const response = await fetch(`${API_BASE}/observability/metrics/prometheus`);
+        document.getElementById("observability-prom").textContent = await response.text();
+      }
+
+      document.getElementById("citizen-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/citizens`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: document.getElementById("citizen-name").value,
+            email: document.getElementById("citizen-email").value,
+            document_type: document.getElementById("citizen-doc-type").value,
+            document_id: document.getElementById("citizen-doc-id").value,
+          }),
+        });
+        refreshCitizens();
+      });
+
+      document.getElementById("client-cert-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const response = await fetch(`${API_BASE}/certificates/client`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: document.getElementById("client-email").value,
+            common_name: document.getElementById("client-cn").value,
+          }),
+        });
+        const payload = await response.json();
+        document.getElementById("handshake").textContent = JSON.stringify(payload, null, 2);
+        refreshCertificates();
+        refreshObservability();
+      });
+
+      document.getElementById("server-cert-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/certificates/server`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hostname: document.getElementById("server-host").value }),
+        });
+        refreshCertificates();
+      });
+
+      document.getElementById("handshake-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const response = await fetch(`${API_BASE}/tls/handshake`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            server_serial: Number(document.getElementById("server-serial").value),
+            client_serial: Number(document.getElementById("client-serial").value),
+          }),
+        });
+        const payload = await response.json();
+        document.getElementById("handshake").textContent = JSON.stringify(payload, null, 2);
+      });
+
+      document.getElementById("acme-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/acme/orders`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain: document.getElementById("acme-domain").value }),
+        });
+        refreshAcme();
+      });
+
+      document.getElementById("acme-complete-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/acme/orders/${document.getElementById("acme-order-id").value}/complete`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token: document.getElementById("acme-token").value }),
+        });
+        refreshAcme();
+      });
+
+      document.getElementById("kms-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/kms/credentials`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: document.getElementById("kms-email").value,
+            common_name: document.getElementById("kms-cn").value,
+          }),
+        });
+        refreshKms();
+      });
+
+      document.getElementById("sign-credential-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/signing/credentials`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ common_name: document.getElementById("sign-cn").value }),
+        });
+        refreshSigning();
+      });
+
+      document.getElementById("artifact-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/signing/artifacts`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            artifact_id: document.getElementById("artifact-id").value,
+            key_alias: document.getElementById("artifact-alias").value,
+            payload: document.getElementById("artifact-payload").value,
+            description: document.getElementById("artifact-desc").value,
+          }),
+        });
+        refreshSigning();
+      });
+
+      document.getElementById("pipeline-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/pipelines`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            application: document.getElementById("pipeline-app").value,
+            environment: document.getElementById("pipeline-env").value,
+            payload: document.getElementById("pipeline-payload").value,
+          }),
+        });
+        refreshPipelines();
+        refreshSigning();
+        refreshKms();
+      });
+
+      document.getElementById("metric-form").addEventListener("submit", async (event) => {
+        event.preventDefault();
+        await fetch(`${API_BASE}/observability/metrics`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: document.getElementById("metric-name").value,
+            value: Number(document.getElementById("metric-value").value),
+            labels: toJsonTextarea(document.getElementById("metric-labels").value),
+          }),
+        });
+        refreshObservability();
+      });
+
+      refreshCitizens();
+      refreshCertificates();
+      refreshAcme();
+      refreshKms();
+      refreshSigning();
+      refreshPipelines();
+      refreshObservability();
+    </script>
+  </body>
+</html>

--- a/modulo1_fundamentos/projeto/README.md
+++ b/modulo1_fundamentos/projeto/README.md
@@ -1,0 +1,42 @@
+# Módulo 1 &mdash; Fundamentos
+
+Este módulo estabelece a base do Cartório Digital com um backend FastAPI e uma página HTML simples. O objetivo é permitir o cadastro de cidadãos que serão usados nos próximos módulos.
+
+## Estrutura
+
+- `backend/`: API em FastAPI com rotas de saúde e cadastro/listagem de cidadãos.
+- `frontend/`: página estática que consome a API.
+
+## Execução
+
+1. Crie um ambiente virtual e instale as dependências:
+
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Inicie a API:
+
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+3. Em outro terminal, sirva o frontend (opcionalmente com o Python HTTP server):
+
+   ```bash
+   cd ../frontend
+   python -m http.server 3000
+   ```
+
+4. Acesse `http://localhost:3000` e cadastre cidadãos. A API responde em `http://localhost:8000`.
+
+## Validação
+
+- Chame `GET http://localhost:8000/health` e confirme que responde `{ "status": "ok" }`.
+- Cadastre cidadãos via frontend ou `POST http://localhost:8000/citizens` com JSON `{ "name": "Alice", "email": "alice@example.com" }`.
+- Liste cidadãos em `GET http://localhost:8000/citizens`.
+
+Nos próximos módulos os registros serão usados para emissão de certificados.

--- a/modulo1_fundamentos/projeto/backend/main.py
+++ b/modulo1_fundamentos/projeto/backend/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Dict
+
+
+class Citizen(BaseModel):
+    name: str
+    email: str
+
+
+app = FastAPI(title="Cartório Digital - Fundamentos")
+registrations: Dict[str, Citizen] = {}
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Return a simple status message so we can wire the frontend later."""
+    return {"status": "ok", "module": "fundamentos"}
+
+
+@app.post("/citizens")
+def enroll_citizen(citizen: Citizen) -> Dict[str, str]:
+    """Register a citizen that will later receive a digital certificate."""
+    registrations[citizen.email] = citizen
+    return {"message": "Citizen registered", "email": citizen.email}
+
+
+@app.get("/citizens")
+def list_citizens() -> Dict[str, Dict[str, str]]:
+    """List all registered citizens."""
+    return {
+        "citizens": {
+            email: citizen.model_dump()
+            for email, citizen in registrations.items()
+        }
+    }

--- a/modulo1_fundamentos/projeto/backend/requirements.txt
+++ b/modulo1_fundamentos/projeto/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo1_fundamentos/projeto/frontend/index.html
+++ b/modulo1_fundamentos/projeto/frontend/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Fundamentos</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      form {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+      input {
+        padding: 0.5rem;
+      }
+      button {
+        padding: 0.5rem 1rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Fundamentos</h1>
+    <p>Cadastre cidadãos para acompanhar a evolução do sistema.</p>
+
+    <form id="citizen-form">
+      <input type="text" id="name" placeholder="Nome" required />
+      <input type="email" id="email" placeholder="E-mail" required />
+      <button type="submit">Cadastrar</button>
+    </form>
+
+    <section>
+      <h2>Registros</h2>
+      <pre id="citizens"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function fetchCitizens() {
+        const response = await fetch(`${API_BASE}/citizens`);
+        const data = await response.json();
+        document.getElementById("citizens").textContent = JSON.stringify(
+          data.citizens,
+          null,
+          2
+        );
+      }
+
+      document
+        .getElementById("citizen-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/citizens`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: document.getElementById("name").value,
+              email: document.getElementById("email").value,
+            }),
+          });
+          if (response.ok) {
+            event.target.reset();
+            fetchCitizens();
+          }
+        });
+
+      fetchCitizens();
+    </script>
+  </body>
+</html>

--- a/modulo2_pkicertificados/projeto/README.md
+++ b/modulo2_pkicertificados/projeto/README.md
@@ -1,0 +1,39 @@
+# Módulo 2 &mdash; PKI e Certificados
+
+Avançamos para a criação de uma autoridade certificadora (AC) interna capaz de emitir certificados X.509 para os cidadãos cadastrados no módulo anterior.
+
+## Destaques
+
+- Autoridade certificadora raiz gerada em memória com chave RSA 2048 bits.
+- Rotas para emissão, listagem, detalhamento e revogação de certificados.
+- Frontend atualizado para exibir o certificado da AC e os certificados emitidos.
+
+## Execução
+
+1. Configure o backend:
+
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   uvicorn main:app --reload
+   ```
+
+2. Sirva o frontend estático:
+
+   ```bash
+   cd ../frontend
+   python -m http.server 3000
+   ```
+
+3. Navegue para `http://localhost:3000`.
+
+## Validação
+
+- Cadastre cidadãos via frontend.
+- Emita certificados informando `Common Name` e e-mail cadastrado.
+- Clique em "Exibir certificado raiz" para obter o PEM da AC.
+- Liste certificados e teste a revogação com `POST /certificates/{serial}/revoke` (via `curl` ou ferramenta HTTP).
+
+Este módulo estabelece a base de PKI usada nos próximos capítulos para TLS, ACME e governança.

--- a/modulo2_pkicertificados/projeto/backend/crypto.py
+++ b/modulo2_pkicertificados/projeto/backend/crypto.py
@@ -1,0 +1,91 @@
+"""Utilities to generate and issue X.509 certificates for the lab environment."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+@dataclass
+class IssuedCertificate:
+    serial_number: int
+    subject: str
+    pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+    revoked: bool = False
+
+
+class CertificateAuthority:
+    """In-memory certificate authority used for the project."""
+
+    def __init__(self, common_name: str) -> None:
+        self.common_name = common_name
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCertificate] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def issue_certificate(self, common_name: str, email: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        serial_number = x509.random_serial_number()
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(serial_number)
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+        )
+        certificate = builder.sign(self._key, hashes.SHA256())
+        issued = IssuedCertificate(
+            serial_number=serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+        )
+        self._issued[serial_number] = issued
+        return issued
+
+    def revoke(self, serial_number: int) -> Optional[IssuedCertificate]:
+        cert = self._issued.get(serial_number)
+        if cert:
+            cert.revoked = True
+        return cert
+
+    def get(self, serial_number: int) -> Optional[IssuedCertificate]:
+        return self._issued.get(serial_number)
+
+    def list_all(self) -> Dict[int, IssuedCertificate]:
+        return dict(self._issued)

--- a/modulo2_pkicertificados/projeto/backend/main.py
+++ b/modulo2_pkicertificados/projeto/backend/main.py
@@ -1,0 +1,92 @@
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+
+from crypto import CertificateAuthority, IssuedCertificate
+
+
+class Citizen(BaseModel):
+    name: str
+    email: EmailStr
+
+
+class CertificateRequest(BaseModel):
+    email: EmailStr
+    common_name: str
+
+
+app = FastAPI(title="Cartório Digital - PKI e Certificados")
+ca = CertificateAuthority("Cartorio Digital CA")
+registrations: Dict[str, Citizen] = {}
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "pki"}
+
+
+@app.post("/citizens")
+def enroll_citizen(citizen: Citizen) -> Dict[str, str]:
+    registrations[citizen.email] = citizen
+    return {"message": "Citizen registered", "email": citizen.email}
+
+
+@app.get("/citizens")
+def list_citizens() -> Dict[str, Dict[str, str]]:
+    return {
+        "citizens": {
+            email: citizen.model_dump()
+            for email, citizen in registrations.items()
+        }
+    }
+
+
+@app.get("/ca")
+def ca_certificate() -> Dict[str, str]:
+    return {"certificate": ca.certificate_pem}
+
+
+@app.post("/certificates")
+def issue_certificate(request: CertificateRequest) -> Dict[str, str]:
+    if request.email not in registrations:
+        raise HTTPException(status_code=404, detail="Citizen not registered")
+    issued = ca.issue_certificate(request.common_name, request.email)
+    return _serialize_certificate(issued)
+
+
+@app.get("/certificates")
+def list_certificates() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "certificates": {
+            str(serial): _serialize_certificate(cert)
+            for serial, cert in ca.list_all().items()
+        }
+    }
+
+
+@app.get("/certificates/{serial_number}")
+def get_certificate(serial_number: int) -> Dict[str, str]:
+    cert = ca.get(serial_number)
+    if not cert:
+        raise HTTPException(status_code=404, detail="Certificate not found")
+    return _serialize_certificate(cert)
+
+
+@app.post("/certificates/{serial_number}/revoke")
+def revoke_certificate(serial_number: int) -> Dict[str, str]:
+    cert = ca.revoke(serial_number)
+    if not cert:
+        raise HTTPException(status_code=404, detail="Certificate not found")
+    return _serialize_certificate(cert)
+
+
+def _serialize_certificate(cert: IssuedCertificate) -> Dict[str, str]:
+    return {
+        "serial_number": str(cert.serial_number),
+        "subject": cert.subject,
+        "pem": cert.pem,
+        "not_valid_before": cert.not_valid_before.isoformat(),
+        "not_valid_after": cert.not_valid_after.isoformat(),
+        "revoked": str(cert.revoked).lower(),
+    }

--- a/modulo2_pkicertificados/projeto/backend/requirements.txt
+++ b/modulo2_pkicertificados/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo2_pkicertificados/projeto/frontend/index.html
+++ b/modulo2_pkicertificados/projeto/frontend/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - PKI</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: grid;
+        grid-template-columns: 1fr 1fr 200px;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button {
+        padding: 0.5rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; PKI e Certificados</h1>
+
+    <section>
+      <h2>Autoridade Certificadora</h2>
+      <button id="fetch-ca">Exibir certificado raiz</button>
+      <pre id="ca-cert"></pre>
+    </section>
+
+    <section>
+      <h2>Cadastro de cidadão</h2>
+      <form id="citizen-form">
+        <input type="text" id="name" placeholder="Nome" required />
+        <input type="email" id="email" placeholder="E-mail" required />
+        <button type="submit">Cadastrar</button>
+      </form>
+      <pre id="citizens"></pre>
+    </section>
+
+    <section>
+      <h2>Solicitação de certificado</h2>
+      <form id="certificate-form">
+        <input type="text" id="cn" placeholder="Common Name" required />
+        <input type="email" id="email-cert" placeholder="E-mail" required />
+        <button type="submit">Emitir certificado</button>
+      </form>
+      <pre id="certificates"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function fetchCitizens() {
+        const response = await fetch(`${API_BASE}/citizens`);
+        const data = await response.json();
+        document.getElementById("citizens").textContent = JSON.stringify(
+          data.citizens,
+          null,
+          2
+        );
+      }
+
+      async function fetchCertificates() {
+        const response = await fetch(`${API_BASE}/certificates`);
+        const data = await response.json();
+        document.getElementById("certificates").textContent = JSON.stringify(
+          data.certificates,
+          null,
+          2
+        );
+      }
+
+      document
+        .getElementById("citizen-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/citizens`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: document.getElementById("name").value,
+              email: document.getElementById("email").value,
+            }),
+          });
+          if (response.ok) {
+            event.target.reset();
+            fetchCitizens();
+          }
+        });
+
+      document
+        .getElementById("certificate-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/certificates`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              common_name: document.getElementById("cn").value,
+              email: document.getElementById("email-cert").value,
+            }),
+          });
+          if (response.ok) {
+            event.target.reset();
+            fetchCertificates();
+          }
+        });
+
+      document.getElementById("fetch-ca").addEventListener("click", async () => {
+        const response = await fetch(`${API_BASE}/ca`);
+        const data = await response.json();
+        document.getElementById("ca-cert").textContent = data.certificate;
+      });
+
+      fetchCitizens();
+      fetchCertificates();
+    </script>
+  </body>
+</html>

--- a/modulo3_tls_mtls/projeto/README.md
+++ b/modulo3_tls_mtls/projeto/README.md
@@ -1,0 +1,36 @@
+# Módulo 3 &mdash; TLS e mTLS
+
+Este módulo expande a AC para suportar certificados de servidor e cliente, além de uma simulação de handshake mTLS utilizando as emissões locais.
+
+## Destaques
+
+- Emissão diferenciada de certificados para cliente (`ExtendedKeyUsage=CLIENT_AUTH`) e servidor (`SERVER_AUTH`).
+- Função `validate_mutual_tls` que verifica revogação e validade antes de aceitar o handshake.
+- Frontend com simulação de validação mTLS.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Sirva o frontend em outro terminal:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Cadastre um cidadão.
+2. Emita um certificado de cliente para o e-mail cadastrado.
+3. Emita um certificado de servidor com o hostname desejado.
+4. Use os números de série retornados na rota `/tls/handshake` para validar a sessão.
+5. Opcionalmente revogue certificados editando a lógica no backend para observar falhas no handshake.
+
+Esses conceitos são utilizados nos módulos seguintes para TLS com ACME e automação.

--- a/modulo3_tls_mtls/projeto/backend/crypto.py
+++ b/modulo3_tls_mtls/projeto/backend/crypto.py
@@ -1,0 +1,119 @@
+"""PKI helper tailored for TLS/mTLS experiments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+@dataclass
+class IssuedCertificate:
+    serial_number: int
+    subject: str
+    pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+    revoked: bool = False
+    purpose: str = "generic"
+
+
+class CertificateAuthority:
+    def __init__(self, common_name: str) -> None:
+        self.common_name = common_name
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCertificate] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def _issue(self, builder: x509.CertificateBuilder, purpose: str) -> IssuedCertificate:
+        certificate = builder.sign(self._key, hashes.SHA256())
+        issued = IssuedCertificate(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+            purpose=purpose,
+        )
+        self._issued[issued.serial_number] = issued
+        return issued
+
+    def issue_client_certificate(self, common_name: str, email: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "client")
+
+    def issue_server_certificate(self, hostname: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=90))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "server")
+
+    def revoke(self, serial_number: int) -> Optional[IssuedCertificate]:
+        cert = self._issued.get(serial_number)
+        if cert:
+            cert.revoked = True
+        return cert
+
+    def get(self, serial_number: int) -> Optional[IssuedCertificate]:
+        return self._issued.get(serial_number)
+
+    def list_all(self) -> Dict[int, IssuedCertificate]:
+        return dict(self._issued)

--- a/modulo3_tls_mtls/projeto/backend/main.py
+++ b/modulo3_tls_mtls/projeto/backend/main.py
@@ -1,0 +1,86 @@
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+
+from crypto import CertificateAuthority, IssuedCertificate
+from tls import validate_mutual_tls
+
+
+class Citizen(BaseModel):
+    name: str
+    email: EmailStr
+
+
+class ClientCertificateRequest(BaseModel):
+    email: EmailStr
+    common_name: str
+
+
+class ServerCertificateRequest(BaseModel):
+    hostname: str
+
+
+class HandshakeRequest(BaseModel):
+    server_serial: int
+    client_serial: int
+
+
+app = FastAPI(title="Cartório Digital - TLS/mTLS")
+ca = CertificateAuthority("Cartorio Digital TLS CA")
+registrations: Dict[str, Citizen] = {}
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "tls"}
+
+
+@app.post("/citizens")
+def enroll_citizen(citizen: Citizen) -> Dict[str, str]:
+    registrations[citizen.email] = citizen
+    return {"message": "Citizen registered", "email": citizen.email}
+
+
+@app.post("/certificates/client")
+def issue_client_certificate(request: ClientCertificateRequest) -> Dict[str, str]:
+    if request.email not in registrations:
+        raise HTTPException(status_code=404, detail="Citizen not registered")
+    cert = ca.issue_client_certificate(request.common_name, request.email)
+    return _serialize_certificate(cert)
+
+
+@app.post("/certificates/server")
+def issue_server_certificate(request: ServerCertificateRequest) -> Dict[str, str]:
+    cert = ca.issue_server_certificate(request.hostname)
+    return _serialize_certificate(cert)
+
+
+@app.get("/certificates")
+def list_certificates() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "certificates": {
+            str(serial): _serialize_certificate(cert)
+            for serial, cert in ca.list_all().items()
+        }
+    }
+
+
+@app.post("/tls/handshake")
+def simulate_handshake(request: HandshakeRequest) -> Dict[str, str]:
+    ok = validate_mutual_tls(ca, request.server_serial, request.client_serial)
+    if not ok:
+        raise HTTPException(status_code=400, detail="mTLS validation failed")
+    return {"message": "mTLS negotiation succeeded"}
+
+
+def _serialize_certificate(cert: IssuedCertificate) -> Dict[str, str]:
+    return {
+        "serial_number": str(cert.serial_number),
+        "subject": cert.subject,
+        "pem": cert.pem,
+        "not_valid_before": cert.not_valid_before.isoformat(),
+        "not_valid_after": cert.not_valid_after.isoformat(),
+        "revoked": str(cert.revoked).lower(),
+        "purpose": cert.purpose,
+    }

--- a/modulo3_tls_mtls/projeto/backend/requirements.txt
+++ b/modulo3_tls_mtls/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo3_tls_mtls/projeto/backend/tls.py
+++ b/modulo3_tls_mtls/projeto/backend/tls.py
@@ -1,0 +1,27 @@
+"""TLS helper functions."""
+from datetime import datetime, timezone
+
+from cryptography import x509
+
+from crypto import CertificateAuthority
+
+
+def validate_mutual_tls(ca: CertificateAuthority, server_serial: int, client_serial: int) -> bool:
+    """Validate that both certificates exist, are not revoked and are valid for mTLS."""
+    server = ca.get(server_serial)
+    client = ca.get(client_serial)
+    if not server or not client:
+        return False
+    if server.revoked or client.revoked:
+        return False
+    now = datetime.now(timezone.utc)
+    if server.not_valid_after < now or client.not_valid_after < now:
+        return False
+
+    server_cert = x509.load_pem_x509_certificate(server.pem.encode())
+    client_cert = x509.load_pem_x509_certificate(client.pem.encode())
+    eku_server = server_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    eku_client = client_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    has_server_auth = any(oid.dotted_string == "1.3.6.1.5.5.7.3.1" for oid in eku_server.value)
+    has_client_auth = any(oid.dotted_string == "1.3.6.1.5.5.7.3.2" for oid in eku_client.value)
+    return has_server_auth and has_client_auth

--- a/modulo3_tls_mtls/projeto/frontend/index.html
+++ b/modulo3_tls_mtls/projeto/frontend/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - TLS/mTLS</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      h2 {
+        margin-top: 2rem;
+      }
+      form {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button,
+      select {
+        padding: 0.5rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; TLS/mTLS</h1>
+
+    <section>
+      <h2>Cadastro de cidadão</h2>
+      <form id="citizen-form">
+        <input type="text" id="name" placeholder="Nome" required />
+        <input type="email" id="email" placeholder="E-mail" required />
+        <button type="submit">Cadastrar</button>
+      </form>
+      <pre id="citizens"></pre>
+    </section>
+
+    <section>
+      <h2>Certificados</h2>
+      <form id="client-cert-form">
+        <input type="text" id="client-cn" placeholder="Common Name" required />
+        <input type="email" id="client-email" placeholder="E-mail" required />
+        <button type="submit">Emitir cliente</button>
+      </form>
+      <form id="server-cert-form">
+        <input type="text" id="hostname" placeholder="Hostname" required />
+        <button type="submit">Emitir servidor</button>
+      </form>
+      <pre id="certificates"></pre>
+    </section>
+
+    <section>
+      <h2>Simulação mTLS</h2>
+      <form id="handshake-form">
+        <input type="number" id="server-serial" placeholder="Serial servidor" required />
+        <input type="number" id="client-serial" placeholder="Serial cliente" required />
+        <button type="submit">Validar</button>
+      </form>
+      <pre id="handshake-result"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function fetchCitizens() {
+        const response = await fetch(`${API_BASE}/citizens`);
+        const data = await response.json();
+        document.getElementById("citizens").textContent = JSON.stringify(
+          data.citizens,
+          null,
+          2
+        );
+      }
+
+      async function fetchCertificates() {
+        const response = await fetch(`${API_BASE}/certificates`);
+        const data = await response.json();
+        document.getElementById("certificates").textContent = JSON.stringify(
+          data.certificates,
+          null,
+          2
+        );
+      }
+
+      document
+        .getElementById("citizen-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/citizens`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: document.getElementById("name").value,
+              email: document.getElementById("email").value,
+            }),
+          });
+          event.target.reset();
+          fetchCitizens();
+        });
+
+      document
+        .getElementById("client-cert-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/certificates/client`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              common_name: document.getElementById("client-cn").value,
+              email: document.getElementById("client-email").value,
+            }),
+          });
+          event.target.reset();
+          fetchCertificates();
+        });
+
+      document
+        .getElementById("server-cert-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/certificates/server`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              hostname: document.getElementById("hostname").value,
+            }),
+          });
+          event.target.reset();
+          fetchCertificates();
+        });
+
+      document
+        .getElementById("handshake-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/tls/handshake`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              server_serial: Number(document.getElementById("server-serial").value),
+              client_serial: Number(document.getElementById("client-serial").value),
+            }),
+          });
+          const payload = await response.json();
+          document.getElementById("handshake-result").textContent = JSON.stringify(
+            payload,
+            null,
+            2
+          );
+        });
+
+      fetchCitizens();
+      fetchCertificates();
+    </script>
+  </body>
+</html>

--- a/modulo4_automacao/projeto/README.md
+++ b/modulo4_automacao/projeto/README.md
@@ -1,0 +1,35 @@
+# Módulo 4 &mdash; Automação ACME
+
+Este módulo automatiza a emissão de certificados de servidor usando um fluxo inspirado no protocolo ACME (Let's Encrypt), com ordens, desafios e validação.
+
+## Destaques
+
+- Geração de tokens de desafio para comprovação de domínio.
+- Emissão automática de certificados de servidor após a validação do token.
+- Listagem de ordens ACME para acompanhamento do fluxo.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Crie uma nova ordem ACME informando o domínio.
+2. Copie o `token` retornado e simule a validação do desafio com o mesmo token na rota `/acme/orders/{id}/complete`.
+3. Ao completar o desafio o backend emitirá um certificado de servidor e marcará a ordem como `valid`.
+4. Consulte `/acme/orders` para auditar o status e número de série do certificado.
+
+Nos próximos módulos incorporamos requisitos regulatórios e integrações corporativas ao fluxo.

--- a/modulo4_automacao/projeto/backend/acme.py
+++ b/modulo4_automacao/projeto/backend/acme.py
@@ -1,0 +1,55 @@
+"""Simplified ACME order management for the project."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from crypto import CertificateAuthority, IssuedCertificate
+
+
+@dataclass
+class AcmeOrder:
+    order_id: str
+    domain: str
+    token: str
+    created_at: datetime
+    status: str = "pending"
+    certificate_serial: int | None = None
+
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) > self.created_at + timedelta(minutes=15)
+
+
+class AcmeDirectory:
+    def __init__(self, ca: CertificateAuthority) -> None:
+        self.ca = ca
+        self._orders: Dict[str, AcmeOrder] = {}
+
+    def new_order(self, domain: str, token: str) -> AcmeOrder:
+        order = AcmeOrder(
+            order_id=f"order-{len(self._orders)+1}",
+            domain=domain,
+            token=token,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._orders[order.order_id] = order
+        return order
+
+    def complete_challenge(self, order_id: str, provided_token: str) -> IssuedCertificate:
+        order = self._orders[order_id]
+        if order.is_expired():
+            order.status = "expired"
+            raise ValueError("Order expired")
+        if order.token != provided_token:
+            raise ValueError("Invalid challenge token")
+        certificate = self.ca.issue_server_certificate(order.domain)
+        order.status = "valid"
+        order.certificate_serial = certificate.serial_number
+        return certificate
+
+    def get_order(self, order_id: str) -> AcmeOrder:
+        return self._orders[order_id]
+
+    def list_orders(self) -> Dict[str, AcmeOrder]:
+        return dict(self._orders)

--- a/modulo4_automacao/projeto/backend/crypto.py
+++ b/modulo4_automacao/projeto/backend/crypto.py
@@ -1,0 +1,119 @@
+"""PKI helper tailored for TLS/mTLS experiments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+@dataclass
+class IssuedCertificate:
+    serial_number: int
+    subject: str
+    pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+    revoked: bool = False
+    purpose: str = "generic"
+
+
+class CertificateAuthority:
+    def __init__(self, common_name: str) -> None:
+        self.common_name = common_name
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCertificate] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def _issue(self, builder: x509.CertificateBuilder, purpose: str) -> IssuedCertificate:
+        certificate = builder.sign(self._key, hashes.SHA256())
+        issued = IssuedCertificate(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+            purpose=purpose,
+        )
+        self._issued[issued.serial_number] = issued
+        return issued
+
+    def issue_client_certificate(self, common_name: str, email: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "client")
+
+    def issue_server_certificate(self, hostname: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=90))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "server")
+
+    def revoke(self, serial_number: int) -> Optional[IssuedCertificate]:
+        cert = self._issued.get(serial_number)
+        if cert:
+            cert.revoked = True
+        return cert
+
+    def get(self, serial_number: int) -> Optional[IssuedCertificate]:
+        return self._issued.get(serial_number)
+
+    def list_all(self) -> Dict[int, IssuedCertificate]:
+        return dict(self._issued)

--- a/modulo4_automacao/projeto/backend/main.py
+++ b/modulo4_automacao/projeto/backend/main.py
@@ -1,0 +1,84 @@
+import secrets
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from acme import AcmeDirectory, AcmeOrder
+from crypto import CertificateAuthority, IssuedCertificate
+
+
+class OrderRequest(BaseModel):
+    domain: str
+
+
+class ChallengeCompletion(BaseModel):
+    token: str
+
+
+app = FastAPI(title="Cartório Digital - Automação ACME")
+ca = CertificateAuthority("Cartorio Digital ACME CA")
+directory = AcmeDirectory(ca)
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "automacao"}
+
+
+@app.get("/ca")
+def get_ca() -> Dict[str, str]:
+    return {"certificate": ca.certificate_pem}
+
+
+@app.post("/acme/orders")
+def new_order(request: OrderRequest) -> Dict[str, str]:
+    token = secrets.token_urlsafe(16)
+    order = directory.new_order(request.domain, token)
+    return _serialize_order(order)
+
+
+@app.post("/acme/orders/{order_id}/complete")
+def complete_order(order_id: str, completion: ChallengeCompletion) -> Dict[str, str]:
+    try:
+        certificate = directory.complete_challenge(order_id, completion.token)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Order not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "message": "order validated",
+        "certificate": _serialize_certificate(certificate),
+    }
+
+
+@app.get("/acme/orders")
+def list_orders() -> Dict[str, Dict[str, str]]:
+    return {
+        "orders": {
+            order_id: _serialize_order(order)
+            for order_id, order in directory.list_orders().items()
+        }
+    }
+
+
+def _serialize_order(order: AcmeOrder) -> Dict[str, str]:
+    return {
+        "order_id": order.order_id,
+        "domain": order.domain,
+        "token": order.token,
+        "status": order.status,
+        "certificate_serial": (
+            str(order.certificate_serial) if order.certificate_serial else None
+        ),
+    }
+
+
+def _serialize_certificate(cert: IssuedCertificate) -> Dict[str, str]:
+    return {
+        "serial_number": str(cert.serial_number),
+        "subject": cert.subject,
+        "pem": cert.pem,
+        "not_valid_before": cert.not_valid_before.isoformat(),
+        "not_valid_after": cert.not_valid_after.isoformat(),
+    }

--- a/modulo4_automacao/projeto/backend/requirements.txt
+++ b/modulo4_automacao/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo4_automacao/projeto/frontend/index.html
+++ b/modulo4_automacao/projeto/frontend/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Automação ACME</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button {
+        padding: 0.5rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Automação ACME</h1>
+
+    <section>
+      <h2>Autoridade Certificadora</h2>
+      <button id="fetch-ca">Exibir certificado raiz</button>
+      <pre id="ca"></pre>
+    </section>
+
+    <section>
+      <h2>Criar ordem ACME</h2>
+      <form id="order-form">
+        <input type="text" id="domain" placeholder="dominio.exemplo" required />
+        <button type="submit">Gerar ordem</button>
+      </form>
+      <pre id="orders"></pre>
+    </section>
+
+    <section>
+      <h2>Completar desafio</h2>
+      <form id="challenge-form">
+        <input type="text" id="order-id" placeholder="ID da ordem" required />
+        <input type="text" id="token" placeholder="Token fornecido" required />
+        <button type="submit">Validar token</button>
+      </form>
+      <pre id="certificate"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function refreshOrders() {
+        const response = await fetch(`${API_BASE}/acme/orders`);
+        const data = await response.json();
+        document.getElementById("orders").textContent = JSON.stringify(
+          data.orders,
+          null,
+          2
+        );
+      }
+
+      document.getElementById("fetch-ca").addEventListener("click", async () => {
+        const response = await fetch(`${API_BASE}/ca`);
+        const data = await response.json();
+        document.getElementById("ca").textContent = data.certificate;
+      });
+
+      document
+        .getElementById("order-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/acme/orders`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ domain: document.getElementById("domain").value }),
+          });
+          const payload = await response.json();
+          document.getElementById("orders").textContent = JSON.stringify(
+            payload,
+            null,
+            2
+          );
+          refreshOrders();
+        });
+
+      document
+        .getElementById("challenge-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(
+            `${API_BASE}/acme/orders/${document.getElementById("order-id").value}/complete`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ token: document.getElementById("token").value }),
+            }
+          );
+          const payload = await response.json();
+          document.getElementById("certificate").textContent = JSON.stringify(
+            payload,
+            null,
+            2
+          );
+          refreshOrders();
+        });
+
+      refreshOrders();
+    </script>
+  </body>
+</html>

--- a/modulo5_regulatorio/projeto/README.md
+++ b/modulo5_regulatorio/projeto/README.md
@@ -1,0 +1,35 @@
+# Módulo 5 &mdash; Requisitos Regulatórios
+
+Neste estágio adicionamos controles de compliance exigidos por normativos (como ITI e ICP-Brasil), garantindo que certificados só sejam emitidos quando a documentação estiver adequada.
+
+## Destaques
+
+- Cadastro de cidadão com tipo e número de documento.
+- Motor de compliance com regras simples (tipo de documento permitido, tamanho mínimo do número e validade mínima do certificado).
+- Auditoria de emissões com resultados de cada regra.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Cadastre cidadãos com documentos válidos.
+2. Solicite um certificado via `/certificates/compliant`.
+3. Verifique o retorno das regras de compliance e o certificado emitido.
+4. Tente informar um tipo de documento inválido para ver a emissão sendo bloqueada com detalhes no log.
+
+Estes controles serão necessários quando integrarmos KMS/HSM e processos auditáveis nos módulos seguintes.

--- a/modulo5_regulatorio/projeto/backend/compliance.py
+++ b/modulo5_regulatorio/projeto/backend/compliance.py
@@ -1,0 +1,50 @@
+"""Simple compliance checks used to emulate requisitos regulatórios."""
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List
+
+from crypto import IssuedCertificate
+
+
+@dataclass
+class CitizenRecord:
+    name: str
+    email: str
+    document_type: str
+    document_id: str
+
+
+@dataclass
+class ComplianceResult:
+    rule_id: str
+    passed: bool
+    detail: str
+
+
+class ComplianceEngine:
+    allowed_documents = {"RG", "CPF", "CNH"}
+
+    def evaluate(self, citizen: CitizenRecord, certificate: IssuedCertificate) -> List[ComplianceResult]:
+        results: List[ComplianceResult] = []
+        results.append(self._check_document_type(citizen))
+        results.append(self._check_document_length(citizen))
+        results.append(self._check_certificate_validity(certificate))
+        return results
+
+    def _check_document_type(self, citizen: CitizenRecord) -> ComplianceResult:
+        passed = citizen.document_type in self.allowed_documents
+        detail = (
+            "Documento permitido" if passed else "Tipo de documento não reconhecido"
+        )
+        return ComplianceResult("DOC_TYPE", passed, detail)
+
+    def _check_document_length(self, citizen: CitizenRecord) -> ComplianceResult:
+        passed = len(citizen.document_id) >= 5
+        detail = "Documento válido" if passed else "Documento muito curto"
+        return ComplianceResult("DOC_LENGTH", passed, detail)
+
+    def _check_certificate_validity(self, certificate: IssuedCertificate) -> ComplianceResult:
+        remaining = certificate.not_valid_after - datetime.now(timezone.utc)
+        passed = remaining.days >= 30
+        detail = f"Validade restante: {remaining.days} dias"
+        return ComplianceResult("CERT_VALIDITY", passed, detail)

--- a/modulo5_regulatorio/projeto/backend/crypto.py
+++ b/modulo5_regulatorio/projeto/backend/crypto.py
@@ -1,0 +1,119 @@
+"""PKI helper tailored for TLS/mTLS experiments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+@dataclass
+class IssuedCertificate:
+    serial_number: int
+    subject: str
+    pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+    revoked: bool = False
+    purpose: str = "generic"
+
+
+class CertificateAuthority:
+    def __init__(self, common_name: str) -> None:
+        self.common_name = common_name
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCertificate] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def _issue(self, builder: x509.CertificateBuilder, purpose: str) -> IssuedCertificate:
+        certificate = builder.sign(self._key, hashes.SHA256())
+        issued = IssuedCertificate(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+            purpose=purpose,
+        )
+        self._issued[issued.serial_number] = issued
+        return issued
+
+    def issue_client_certificate(self, common_name: str, email: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "client")
+
+    def issue_server_certificate(self, hostname: str) -> IssuedCertificate:
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostname)])
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(self._key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=90))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(hostname)]), critical=False
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False,
+            )
+        )
+        return self._issue(builder, "server")
+
+    def revoke(self, serial_number: int) -> Optional[IssuedCertificate]:
+        cert = self._issued.get(serial_number)
+        if cert:
+            cert.revoked = True
+        return cert
+
+    def get(self, serial_number: int) -> Optional[IssuedCertificate]:
+        return self._issued.get(serial_number)
+
+    def list_all(self) -> Dict[int, IssuedCertificate]:
+        return dict(self._issued)

--- a/modulo5_regulatorio/projeto/backend/main.py
+++ b/modulo5_regulatorio/projeto/backend/main.py
@@ -1,0 +1,74 @@
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+
+from compliance import CitizenRecord, ComplianceEngine
+from crypto import CertificateAuthority, IssuedCertificate
+
+
+class CitizenInput(BaseModel):
+    name: str
+    email: EmailStr
+    document_type: str
+    document_id: str
+
+
+class CertificateRequest(BaseModel):
+    email: EmailStr
+    common_name: str
+
+
+app = FastAPI(title="Cartório Digital - Requisitos Regulatórios")
+ca = CertificateAuthority("Cartorio Digital Compliance CA")
+compliance_engine = ComplianceEngine()
+registrations: Dict[str, CitizenRecord] = {}
+audit_log: List[Dict[str, object]] = []
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "regulatorio"}
+
+
+@app.post("/citizens")
+def register_citizen(citizen: CitizenInput) -> Dict[str, str]:
+    record = CitizenRecord(**citizen.model_dump())
+    registrations[citizen.email] = record
+    return {"message": "Citizen registered", "email": citizen.email}
+
+
+@app.post("/certificates/compliant")
+def issue_compliant_certificate(request: CertificateRequest) -> Dict[str, object]:
+    citizen = registrations.get(request.email)
+    if not citizen:
+        raise HTTPException(status_code=404, detail="Citizen not registered")
+    certificate = ca.issue_client_certificate(request.common_name, request.email)
+    results = compliance_engine.evaluate(citizen, certificate)
+    audit_entry = {
+        "email": citizen.email,
+        "results": [result.__dict__ for result in results],
+        "certificate_serial": certificate.serial_number,
+    }
+    audit_log.append(audit_entry)
+    if not all(result.passed for result in results):
+        raise HTTPException(status_code=400, detail=audit_entry)
+    return {
+        "certificate": _serialize_certificate(certificate),
+        "compliance": audit_entry,
+    }
+
+
+@app.get("/audit")
+def list_audit() -> Dict[str, List[Dict[str, object]]]:
+    return {"entries": audit_log}
+
+
+def _serialize_certificate(cert: IssuedCertificate) -> Dict[str, str]:
+    return {
+        "serial_number": str(cert.serial_number),
+        "subject": cert.subject,
+        "pem": cert.pem,
+        "not_valid_before": cert.not_valid_before.isoformat(),
+        "not_valid_after": cert.not_valid_after.isoformat(),
+    }

--- a/modulo5_regulatorio/projeto/backend/requirements.txt
+++ b/modulo5_regulatorio/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo5_regulatorio/projeto/frontend/index.html
+++ b/modulo5_regulatorio/projeto/frontend/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Requisitos Regulatórios</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr) 200px;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button,
+      select {
+        padding: 0.5rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Requisitos Regulatórios</h1>
+
+    <section>
+      <h2>Cadastro com documentação</h2>
+      <form id="citizen-form">
+        <input type="text" id="name" placeholder="Nome" required />
+        <input type="email" id="email" placeholder="E-mail" required />
+        <select id="doc-type">
+          <option value="RG">RG</option>
+          <option value="CPF">CPF</option>
+          <option value="CNH">CNH</option>
+        </select>
+        <input type="text" id="doc-id" placeholder="Número do documento" required />
+        <button type="submit">Cadastrar</button>
+      </form>
+    </section>
+
+    <section>
+      <h2>Emissão com checagem de compliance</h2>
+      <form id="certificate-form">
+        <input type="email" id="cert-email" placeholder="E-mail cadastrado" required />
+        <input type="text" id="cn" placeholder="Common Name" required />
+        <button type="submit">Emitir certificado</button>
+      </form>
+      <pre id="result"></pre>
+    </section>
+
+    <section>
+      <h2>Auditoria</h2>
+      <button id="refresh-audit">Atualizar auditoria</button>
+      <pre id="audit"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      document
+        .getElementById("citizen-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/citizens`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: document.getElementById("name").value,
+              email: document.getElementById("email").value,
+              document_type: document.getElementById("doc-type").value,
+              document_id: document.getElementById("doc-id").value,
+            }),
+          });
+          event.target.reset();
+          refreshAudit();
+        });
+
+      document
+        .getElementById("certificate-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/certificates/compliant`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: document.getElementById("cert-email").value,
+              common_name: document.getElementById("cn").value,
+            }),
+          });
+          const payload = await response.json();
+          document.getElementById("result").textContent = JSON.stringify(
+            payload,
+            null,
+            2
+          );
+          refreshAudit();
+        });
+
+      document.getElementById("refresh-audit").addEventListener("click", () => {
+        refreshAudit();
+      });
+
+      async function refreshAudit() {
+        const response = await fetch(`${API_BASE}/audit`);
+        const data = await response.json();
+        document.getElementById("audit").textContent = JSON.stringify(
+          data.entries,
+          null,
+          2
+        );
+      }
+
+      refreshAudit();
+    </script>
+  </body>
+</html>

--- a/modulo6_kms_hsm/projeto/README.md
+++ b/modulo6_kms_hsm/projeto/README.md
@@ -1,0 +1,35 @@
+# Módulo 6 &mdash; Integração com KMS/HSM
+
+Nesta etapa as chaves privadas de titulares não ficam mais em disco. Uma camada mock de KMS/HSM gera, armazena e usa as chaves para assinar dados, enquanto a AC emite o certificado com base na chave protegida.
+
+## Destaques
+
+- `MockKMS` expõe operações de criação de chave e assinatura (PSS/SHA-256).
+- AC gera certificados usando apenas a chave pública retornada pelo KMS (suportando key alias).
+- Endpoint para assinatura de payloads, simulando uso de HSM para operações sensíveis.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Emita uma credencial via `/credentials` e observe o alias retornado.
+2. Liste as chaves em `/kms/keys` para confirmar que o alias está protegido pelo KMS.
+3. Utilize `/kms/sign` informando `alias` e `payload` para gerar uma assinatura base64.
+4. Repare que o certificado emitido contém a chave pública proveniente do KMS.
+
+A partir daqui podemos assinar artefatos e integrar pipelines usando as chaves protegidas.

--- a/modulo6_kms_hsm/projeto/backend/crypto.py
+++ b/modulo6_kms_hsm/projeto/backend/crypto.py
@@ -1,0 +1,89 @@
+"""Certificate issuance backed by a mock KMS."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from kms import MockKMS
+
+
+@dataclass
+class IssuedCredential:
+    serial_number: int
+    subject: str
+    certificate_pem: str
+    key_alias: str
+    public_key_pem: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+
+
+class KmsBackedCA:
+    def __init__(self, common_name: str, kms: MockKMS) -> None:
+        self.kms = kms
+        self.common_name = common_name
+        self._root_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._root_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._root_key, hashes.SHA256())
+        )
+        self._issued: Dict[int, IssuedCredential] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def issue_certificate(self, common_name: str, email: str) -> IssuedCredential:
+        alias = f"identity/{len(self._issued)+1}"
+        key_metadata = self.kms.create_key(alias)
+        now = datetime.now(timezone.utc)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                        x509.NameAttribute(NameOID.EMAIL_ADDRESS, email),
+                    ]
+                )
+            )
+            .issuer_name(self._certificate.subject)
+            .public_key(
+                serialization.load_pem_public_key(key_metadata.public_key_pem.encode())
+            )
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+        ).sign(self._root_key, hashes.SHA256())
+
+        credential = IssuedCredential(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            certificate_pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            key_alias=key_metadata.alias,
+            public_key_pem=key_metadata.public_key_pem,
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+        )
+        self._issued[credential.serial_number] = credential
+        return credential
+
+    def list_credentials(self) -> Dict[int, IssuedCredential]:
+        return dict(self._issued)

--- a/modulo6_kms_hsm/projeto/backend/kms.py
+++ b/modulo6_kms_hsm/projeto/backend/kms.py
@@ -1,0 +1,45 @@
+"""Mock KMS/HSM integration layer."""
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Dict
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+@dataclass
+class KeyMetadata:
+    alias: str
+    public_key_pem: str
+
+
+class MockKMS:
+    def __init__(self) -> None:
+        self._keys: Dict[str, rsa.RSAPrivateKey] = {}
+
+    def create_key(self, alias: str) -> KeyMetadata:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._keys[alias] = private_key
+        public_pem = (
+            private_key.public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode()
+        )
+        return KeyMetadata(alias=alias, public_key_pem=public_pem)
+
+    def sign(self, alias: str, data: bytes) -> str:
+        key = self._keys[alias]
+        signature = key.sign(
+            data,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode()
+
+    def list_keys(self) -> Dict[str, int]:
+        return {alias: key.key_size for alias, key in self._keys.items()}

--- a/modulo6_kms_hsm/projeto/backend/main.py
+++ b/modulo6_kms_hsm/projeto/backend/main.py
@@ -1,0 +1,75 @@
+import hashlib
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+
+from crypto import IssuedCredential, KmsBackedCA
+from kms import MockKMS
+
+
+class CredentialRequest(BaseModel):
+    email: EmailStr
+    common_name: str
+
+
+class SignRequest(BaseModel):
+    alias: str
+    payload: str
+
+
+app = FastAPI(title="Cartório Digital - Integração KMS/HSM")
+kms = MockKMS()
+ca = KmsBackedCA("Cartorio Digital KMS CA", kms)
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "kms-hsm"}
+
+
+@app.get("/ca")
+def get_ca() -> Dict[str, str]:
+    return {"certificate": ca.certificate_pem}
+
+
+@app.post("/credentials")
+def issue_credential(request: CredentialRequest) -> Dict[str, str]:
+    credential = ca.issue_certificate(request.common_name, request.email)
+    return _serialize_credential(credential)
+
+
+@app.get("/credentials")
+def list_credentials() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "credentials": {
+            str(serial): _serialize_credential(credential)
+            for serial, credential in ca.list_credentials().items()
+        }
+    }
+
+
+@app.post("/kms/sign")
+def sign_with_kms(request: SignRequest) -> Dict[str, str]:
+    if request.alias not in kms.list_keys():
+        raise HTTPException(status_code=404, detail="Alias not found")
+    digest = hashlib.sha256(request.payload.encode()).digest()
+    signature = kms.sign(request.alias, digest)
+    return {"signature": signature}
+
+
+@app.get("/kms/keys")
+def list_keys() -> Dict[str, Dict[str, int]]:
+    return {"keys": kms.list_keys()}
+
+
+def _serialize_credential(credential: IssuedCredential) -> Dict[str, str]:
+    return {
+        "serial_number": str(credential.serial_number),
+        "subject": credential.subject,
+        "certificate": credential.certificate_pem,
+        "key_alias": credential.key_alias,
+        "public_key": credential.public_key_pem,
+        "not_valid_before": credential.not_valid_before.isoformat(),
+        "not_valid_after": credential.not_valid_after.isoformat(),
+    }

--- a/modulo6_kms_hsm/projeto/backend/requirements.txt
+++ b/modulo6_kms_hsm/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo6_kms_hsm/projeto/frontend/index.html
+++ b/modulo6_kms_hsm/projeto/frontend/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Integração KMS/HSM</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button {
+        padding: 0.5rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Integração KMS/HSM</h1>
+
+    <section>
+      <h2>Emitir credencial com chave protegida</h2>
+      <form id="credential-form">
+        <input type="email" id="email" placeholder="E-mail" required />
+        <input type="text" id="cn" placeholder="Common Name" required />
+        <button type="submit">Emitir</button>
+      </form>
+      <pre id="credentials"></pre>
+    </section>
+
+    <section>
+      <h2>Assinatura via KMS</h2>
+      <form id="sign-form">
+        <input type="text" id="alias" placeholder="Alias da chave" required />
+        <input type="text" id="payload" placeholder="Payload" required />
+        <button type="submit">Assinar</button>
+      </form>
+      <pre id="signature"></pre>
+    </section>
+
+    <section>
+      <h2>Chaves disponíveis</h2>
+      <button id="refresh-keys">Atualizar lista</button>
+      <pre id="keys"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function refreshCredentials() {
+        const response = await fetch(`${API_BASE}/credentials`);
+        const data = await response.json();
+        document.getElementById("credentials").textContent = JSON.stringify(
+          data.credentials,
+          null,
+          2
+        );
+      }
+
+      async function refreshKeys() {
+        const response = await fetch(`${API_BASE}/kms/keys`);
+        const data = await response.json();
+        document.getElementById("keys").textContent = JSON.stringify(
+          data.keys,
+          null,
+          2
+        );
+      }
+
+      document
+        .getElementById("credential-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/credentials`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: document.getElementById("email").value,
+              common_name: document.getElementById("cn").value,
+            }),
+          });
+          refreshCredentials();
+          refreshKeys();
+        });
+
+      document
+        .getElementById("sign-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          const response = await fetch(`${API_BASE}/kms/sign`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              alias: document.getElementById("alias").value,
+              payload: document.getElementById("payload").value,
+            }),
+          });
+          const payload = await response.json();
+          document.getElementById("signature").textContent = JSON.stringify(
+            payload,
+            null,
+            2
+          );
+        });
+
+      document.getElementById("refresh-keys").addEventListener("click", () => {
+        refreshKeys();
+      });
+
+      refreshCredentials();
+      refreshKeys();
+    </script>
+  </body>
+</html>

--- a/modulo7_assinatura_artefatos/projeto/README.md
+++ b/modulo7_assinatura_artefatos/projeto/README.md
@@ -1,0 +1,35 @@
+# Módulo 7 &mdash; Assinatura de Artefatos
+
+Com o KMS integrado, adicionamos certificados de code signing e um fluxo de assinatura de artefatos para distribuir software com cadeias confiáveis.
+
+## Destaques
+
+- AC dedicada para emissão de certificados com EKU `CODE_SIGNING`.
+- Alias gerenciados pelo KMS para proteger as chaves privadas.
+- Registro de artefatos assinados contendo hash (SHA-256) e assinatura base64.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Gere uma credencial de code signing.
+2. Assine um artefato informando alias e payload (ex.: conteúdo de um binário ou manifesto).
+3. Consulte `/signing/artifacts` para visualizar hash, assinatura e metadados.
+4. Use a chave pública do certificado emitido para validar a assinatura externamente.
+
+Essa etapa prepara a automação de pipelines e liberações seguras abordada no próximo módulo.

--- a/modulo7_assinatura_artefatos/projeto/backend/crypto.py
+++ b/modulo7_assinatura_artefatos/projeto/backend/crypto.py
@@ -1,0 +1,83 @@
+"""Support for code-signing certificates."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from kms import MockKMS
+
+
+@dataclass
+class SigningCredential:
+    serial_number: int
+    subject: str
+    certificate_pem: str
+    key_alias: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+
+
+class CodeSigningCA:
+    def __init__(self, common_name: str, kms: MockKMS) -> None:
+        self.kms = kms
+        self._root_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._root_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._root_key, hashes.SHA256())
+        )
+        self._issued: Dict[int, SigningCredential] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def issue_signing_certificate(self, common_name: str) -> SigningCredential:
+        alias = f"code-sign/{len(self._issued)+1}"
+        key_metadata = self.kms.create_key(alias)
+        now = datetime.now(timezone.utc)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)]))
+            .issuer_name(self._certificate.subject)
+            .public_key(
+                serialization.load_pem_public_key(key_metadata.public_key_pem.encode())
+            )
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=180))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CODE_SIGNING]),
+                critical=False,
+            )
+        ).sign(self._root_key, hashes.SHA256())
+
+        credential = SigningCredential(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            certificate_pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            key_alias=alias,
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+        )
+        self._issued[certificate.serial_number] = credential
+        return credential
+
+    def list_credentials(self) -> Dict[int, SigningCredential]:
+        return dict(self._issued)

--- a/modulo7_assinatura_artefatos/projeto/backend/kms.py
+++ b/modulo7_assinatura_artefatos/projeto/backend/kms.py
@@ -1,0 +1,45 @@
+"""Mock KMS/HSM integration layer."""
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Dict
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+@dataclass
+class KeyMetadata:
+    alias: str
+    public_key_pem: str
+
+
+class MockKMS:
+    def __init__(self) -> None:
+        self._keys: Dict[str, rsa.RSAPrivateKey] = {}
+
+    def create_key(self, alias: str) -> KeyMetadata:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._keys[alias] = private_key
+        public_pem = (
+            private_key.public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode()
+        )
+        return KeyMetadata(alias=alias, public_key_pem=public_pem)
+
+    def sign(self, alias: str, data: bytes) -> str:
+        key = self._keys[alias]
+        signature = key.sign(
+            data,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode()
+
+    def list_keys(self) -> Dict[str, int]:
+        return {alias: key.key_size for alias, key in self._keys.items()}

--- a/modulo7_assinatura_artefatos/projeto/backend/main.py
+++ b/modulo7_assinatura_artefatos/projeto/backend/main.py
@@ -1,0 +1,97 @@
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from crypto import CodeSigningCA, SigningCredential
+from kms import MockKMS
+from signing import ArtifactSigner, SignedArtifact
+
+
+class CredentialRequest(BaseModel):
+    common_name: str
+
+
+class ArtifactRequest(BaseModel):
+    artifact_id: str
+    key_alias: str
+    payload: str
+    description: str | None = None
+
+
+app = FastAPI(title="Cartório Digital - Assinatura de Artefatos")
+kms = MockKMS()
+ca = CodeSigningCA("Cartorio Digital Code Signing", kms)
+signer = ArtifactSigner(kms)
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "assinatura"}
+
+
+@app.post("/signing/credentials")
+def issue_signing_credential(request: CredentialRequest) -> Dict[str, str]:
+    credential = ca.issue_signing_certificate(request.common_name)
+    return _serialize_credential(credential)
+
+
+@app.get("/signing/credentials")
+def list_credentials() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "credentials": {
+            str(serial): _serialize_credential(credential)
+            for serial, credential in ca.list_credentials().items()
+        }
+    }
+
+
+@app.post("/signing/artifacts")
+def sign_artifact(request: ArtifactRequest) -> Dict[str, str]:
+    if request.key_alias not in kms.list_keys():
+        raise HTTPException(status_code=404, detail="Key alias not found")
+    metadata = {"description": request.description or ""}
+    artifact = signer.sign(
+        request.artifact_id,
+        request.key_alias,
+        request.payload.encode(),
+        metadata,
+    )
+    return _serialize_artifact(artifact)
+
+
+@app.get("/signing/artifacts")
+def list_signed_artifacts() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "artifacts": {
+            artifact_id: _serialize_artifact(artifact)
+            for artifact_id, artifact in signer.list_signed().items()
+        }
+    }
+
+
+@app.get("/kms/keys")
+def list_keys() -> Dict[str, Dict[str, int]]:
+    return {"keys": kms.list_keys()}
+
+
+def _serialize_credential(credential: SigningCredential) -> Dict[str, str]:
+    return {
+        "serial_number": str(credential.serial_number),
+        "subject": credential.subject,
+        "certificate": credential.certificate_pem,
+        "key_alias": credential.key_alias,
+        "not_valid_before": credential.not_valid_before.isoformat(),
+        "not_valid_after": credential.not_valid_after.isoformat(),
+    }
+
+
+def _serialize_artifact(artifact: SignedArtifact) -> Dict[str, str]:
+    return {
+        "artifact_id": artifact.artifact_id,
+        "digest": artifact.digest,
+        "signature": artifact.signature,
+        "key_alias": artifact.key_alias,
+        "signed_at": artifact.signed_at.isoformat(),
+        "metadata": artifact.metadata,
+    }

--- a/modulo7_assinatura_artefatos/projeto/backend/requirements.txt
+++ b/modulo7_assinatura_artefatos/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo7_assinatura_artefatos/projeto/backend/signing.py
+++ b/modulo7_assinatura_artefatos/projeto/backend/signing.py
@@ -1,0 +1,43 @@
+"""Artifact signing workflow using the mock KMS."""
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict
+
+from kms import MockKMS
+
+
+@dataclass
+class SignedArtifact:
+    artifact_id: str
+    digest: str
+    signature: str
+    key_alias: str
+    signed_at: datetime
+    metadata: Dict[str, str]
+
+
+class ArtifactSigner:
+    def __init__(self, kms: MockKMS) -> None:
+        self.kms = kms
+        self._signed: Dict[str, SignedArtifact] = {}
+
+    def sign(self, artifact_id: str, key_alias: str, payload: bytes, metadata: Dict[str, str]) -> SignedArtifact:
+        digest_bytes = hashlib.sha256(payload).digest()
+        signature = self.kms.sign(key_alias, digest_bytes)
+        artifact = SignedArtifact(
+            artifact_id=artifact_id,
+            digest=base64.b64encode(digest_bytes).decode(),
+            signature=signature,
+            key_alias=key_alias,
+            signed_at=datetime.now(timezone.utc),
+            metadata=metadata,
+        )
+        self._signed[artifact_id] = artifact
+        return artifact
+
+    def list_signed(self) -> Dict[str, SignedArtifact]:
+        return dict(self._signed)

--- a/modulo7_assinatura_artefatos/projeto/frontend/index.html
+++ b/modulo7_assinatura_artefatos/projeto/frontend/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Assinatura de Artefatos</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      input,
+      button,
+      textarea {
+        padding: 0.5rem;
+      }
+      textarea {
+        width: 400px;
+        height: 100px;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Assinatura de Artefatos</h1>
+
+    <section>
+      <h2>Emitir certificado de code signing</h2>
+      <form id="credential-form">
+        <input type="text" id="cn" placeholder="Common Name" required />
+        <button type="submit">Gerar credencial</button>
+      </form>
+      <pre id="credentials"></pre>
+    </section>
+
+    <section>
+      <h2>Assinar artefato</h2>
+      <form id="artifact-form">
+        <input type="text" id="artifact-id" placeholder="ID do artefato" required />
+        <input type="text" id="alias" placeholder="Alias da chave" required />
+        <textarea id="payload" placeholder="Conteúdo para assinatura" required></textarea>
+        <input type="text" id="description" placeholder="Descrição" />
+        <button type="submit">Assinar</button>
+      </form>
+      <pre id="artifacts"></pre>
+    </section>
+
+    <section>
+      <h2>Chaves ativas</h2>
+      <button id="refresh-keys">Atualizar</button>
+      <pre id="keys"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function refreshCredentials() {
+        const response = await fetch(`${API_BASE}/signing/credentials`);
+        const data = await response.json();
+        document.getElementById("credentials").textContent = JSON.stringify(
+          data.credentials,
+          null,
+          2
+        );
+      }
+
+      async function refreshArtifacts() {
+        const response = await fetch(`${API_BASE}/signing/artifacts`);
+        const data = await response.json();
+        document.getElementById("artifacts").textContent = JSON.stringify(
+          data.artifacts,
+          null,
+          2
+        );
+      }
+
+      async function refreshKeys() {
+        const response = await fetch(`${API_BASE}/kms/keys`);
+        const data = await response.json();
+        document.getElementById("keys").textContent = JSON.stringify(
+          data.keys,
+          null,
+          2
+        );
+      }
+
+      document
+        .getElementById("credential-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/signing/credentials`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              common_name: document.getElementById("cn").value,
+            }),
+          });
+          refreshCredentials();
+          refreshKeys();
+        });
+
+      document
+        .getElementById("artifact-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/signing/artifacts`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              artifact_id: document.getElementById("artifact-id").value,
+              key_alias: document.getElementById("alias").value,
+              payload: document.getElementById("payload").value,
+              description: document.getElementById("description").value,
+            }),
+          });
+          refreshArtifacts();
+        });
+
+      document.getElementById("refresh-keys").addEventListener("click", () => {
+        refreshKeys();
+      });
+
+      refreshCredentials();
+      refreshArtifacts();
+      refreshKeys();
+    </script>
+  </body>
+</html>

--- a/modulo8_cloud_cicd/projeto/README.md
+++ b/modulo8_cloud_cicd/projeto/README.md
@@ -1,0 +1,35 @@
+# Módulo 8 &mdash; Cloud e CI/CD
+
+Conectamos a emissão de certificados e assinatura de artefatos a um pipeline CI/CD simulando deploys em nuvem, demonstrando como integrar governança de certificados aos processos de entrega contínua.
+
+## Destaques
+
+- Orquestrador de pipeline que gera certificados de code signing, assina artefatos e marca deploys por ambiente.
+- Persistência em memória dos pipelines executados, com passos e timestamps.
+- Exposição de chaves gerenciadas pelo KMS para auditoria de infraestrutura.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Execute um pipeline informando aplicação, ambiente e payload.
+2. Verifique as etapas (`build`, `sign`, `deploy`) e os detalhes no retorno.
+3. Consulte `/pipelines` e `/kms/keys` para acompanhar execuções e chaves criadas automaticamente.
+4. Observe que cada execução cria uma nova credencial com alias exclusivo e assinatura vinculada.
+
+O próximo módulo adiciona observabilidade para monitorar todo esse ecossistema.

--- a/modulo8_cloud_cicd/projeto/backend/crypto.py
+++ b/modulo8_cloud_cicd/projeto/backend/crypto.py
@@ -1,0 +1,83 @@
+"""Support for code-signing certificates."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from kms import MockKMS
+
+
+@dataclass
+class SigningCredential:
+    serial_number: int
+    subject: str
+    certificate_pem: str
+    key_alias: str
+    not_valid_before: datetime
+    not_valid_after: datetime
+
+
+class CodeSigningCA:
+    def __init__(self, common_name: str, kms: MockKMS) -> None:
+        self.kms = kms
+        self._root_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        now = datetime.now(timezone.utc)
+        self._certificate = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(self._root_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(self._root_key, hashes.SHA256())
+        )
+        self._issued: Dict[int, SigningCredential] = {}
+
+    @property
+    def certificate_pem(self) -> str:
+        return self._certificate.public_bytes(serialization.Encoding.PEM).decode()
+
+    def issue_signing_certificate(self, common_name: str) -> SigningCredential:
+        alias = f"code-sign/{len(self._issued)+1}"
+        key_metadata = self.kms.create_key(alias)
+        now = datetime.now(timezone.utc)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)]))
+            .issuer_name(self._certificate.subject)
+            .public_key(
+                serialization.load_pem_public_key(key_metadata.public_key_pem.encode())
+            )
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=180))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CODE_SIGNING]),
+                critical=False,
+            )
+        ).sign(self._root_key, hashes.SHA256())
+
+        credential = SigningCredential(
+            serial_number=certificate.serial_number,
+            subject=certificate.subject.rfc4514_string(),
+            certificate_pem=certificate.public_bytes(serialization.Encoding.PEM).decode(),
+            key_alias=alias,
+            not_valid_before=certificate.not_valid_before,
+            not_valid_after=certificate.not_valid_after,
+        )
+        self._issued[certificate.serial_number] = credential
+        return credential
+
+    def list_credentials(self) -> Dict[int, SigningCredential]:
+        return dict(self._issued)

--- a/modulo8_cloud_cicd/projeto/backend/kms.py
+++ b/modulo8_cloud_cicd/projeto/backend/kms.py
@@ -1,0 +1,45 @@
+"""Mock KMS/HSM integration layer."""
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Dict
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+@dataclass
+class KeyMetadata:
+    alias: str
+    public_key_pem: str
+
+
+class MockKMS:
+    def __init__(self) -> None:
+        self._keys: Dict[str, rsa.RSAPrivateKey] = {}
+
+    def create_key(self, alias: str) -> KeyMetadata:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._keys[alias] = private_key
+        public_pem = (
+            private_key.public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode()
+        )
+        return KeyMetadata(alias=alias, public_key_pem=public_pem)
+
+    def sign(self, alias: str, data: bytes) -> str:
+        key = self._keys[alias]
+        signature = key.sign(
+            data,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode()
+
+    def list_keys(self) -> Dict[str, int]:
+        return {alias: key.key_size for alias, key in self._keys.items()}

--- a/modulo8_cloud_cicd/projeto/backend/main.py
+++ b/modulo8_cloud_cicd/projeto/backend/main.py
@@ -1,0 +1,131 @@
+from typing import Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from crypto import CodeSigningCA
+from kms import MockKMS
+from pipeline import PipelineOrchestrator
+from signing import ArtifactSigner
+
+
+class PipelineRequest(BaseModel):
+    application: str
+    environment: str
+    payload: str
+
+
+app = FastAPI(title="Cartório Digital - Cloud e CI/CD")
+kms = MockKMS()
+ca = CodeSigningCA("Cartorio Digital CI/CD", kms)
+signer = ArtifactSigner(kms)
+orchestrator = PipelineOrchestrator(kms, ca, signer)
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "cloud-cicd"}
+
+
+@app.post("/pipelines")
+def trigger_pipeline(request: PipelineRequest) -> Dict[str, object]:
+    execution = orchestrator.run_pipeline(
+        application=request.application,
+        environment=request.environment,
+        payload=request.payload,
+    )
+    return _serialize_execution(execution)
+
+
+@app.get("/pipelines")
+def list_pipelines() -> Dict[str, Dict[str, object]]:
+    return {
+        "pipelines": {
+            pipeline_id: _serialize_execution(execution)
+            for pipeline_id, execution in orchestrator.list_executions().items()
+        }
+    }
+
+
+@app.get("/kms/keys")
+def list_keys() -> Dict[str, Dict[str, int]]:
+    return {"keys": kms.list_keys()}
+
+
+@app.get("/signing/credentials")
+def list_credentials() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "credentials": {
+            str(serial): _serialize_credential(credential)
+            for serial, credential in ca.list_credentials().items()
+        }
+    }
+
+
+@app.get("/signing/artifacts")
+def list_artifacts() -> Dict[str, Dict[str, Dict[str, str]]]:
+    return {
+        "artifacts": {
+            artifact_id: _serialize_artifact(artifact)
+            for artifact_id, artifact in signer.list_signed().items()
+        }
+    }
+
+
+def _serialize_execution(execution) -> Dict[str, object]:
+    return {
+        "pipeline_id": execution.pipeline_id,
+        "application": execution.application,
+        "environment": execution.environment,
+        "credential": {
+            "serial_number": str(execution.credential.serial_number),
+            "certificate": execution.credential.certificate_pem,
+            "key_alias": execution.credential.key_alias,
+        },
+        "artifact": {
+            "id": execution.artifact.artifact_id,
+            "digest": execution.artifact.digest,
+            "signature": execution.artifact.signature,
+        },
+        "steps": [
+            {
+                "name": step.name,
+                "status": step.status,
+                "detail": step.detail,
+                "completed_at": step.completed_at.isoformat(),
+            }
+            for step in execution.steps
+        ],
+    }
+
+
+def _serialize_credential(credential) -> Dict[str, str]:
+    return {
+        "serial_number": str(credential.serial_number),
+        "subject": credential.subject,
+        "certificate": credential.certificate_pem,
+        "key_alias": credential.key_alias,
+        "not_valid_before": credential.not_valid_before.isoformat(),
+        "not_valid_after": credential.not_valid_after.isoformat(),
+    }
+
+
+def _serialize_artifact(artifact) -> Dict[str, str]:
+    return {
+        "artifact_id": artifact.artifact_id,
+        "digest": artifact.digest,
+        "signature": artifact.signature,
+        "key_alias": artifact.key_alias,
+        "signed_at": artifact.signed_at.isoformat(),
+        "metadata": artifact.metadata,
+    }
+from typing import Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from crypto import CodeSigningCA
+from kms import MockKMS
+from pipeline import PipelineOrchestrator
+from signing import ArtifactSigner
+

--- a/modulo8_cloud_cicd/projeto/backend/pipeline.py
+++ b/modulo8_cloud_cicd/projeto/backend/pipeline.py
@@ -1,0 +1,94 @@
+"""CI/CD orchestration utilities."""
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List
+
+from crypto import CodeSigningCA, SigningCredential
+from kms import MockKMS
+from signing import ArtifactSigner, SignedArtifact
+
+
+@dataclass
+class PipelineStep:
+    name: str
+    status: str
+    detail: str
+    completed_at: datetime
+
+
+@dataclass
+class PipelineExecution:
+    pipeline_id: str
+    application: str
+    environment: str
+    credential: SigningCredential
+    artifact: SignedArtifact
+    steps: List[PipelineStep] = field(default_factory=list)
+
+
+class PipelineOrchestrator:
+    def __init__(self, kms: MockKMS, ca: CodeSigningCA, signer: ArtifactSigner) -> None:
+        self.kms = kms
+        self.ca = ca
+        self.signer = signer
+        self._executions: Dict[str, PipelineExecution] = {}
+
+    def run_pipeline(self, application: str, environment: str, payload: str) -> PipelineExecution:
+        pipeline_id = f"pipeline-{len(self._executions)+1}"
+        credential = self.ca.issue_signing_certificate(f"{application}-{environment}")
+        steps: List[PipelineStep] = []
+
+        # Build step
+        digest = hashlib.sha256(payload.encode()).digest()
+        steps.append(
+            PipelineStep(
+                name="build",
+                status="success",
+                detail=f"SHA256={base64.b64encode(digest).decode()}",
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        # Sign step
+        artifact = self.signer.sign(
+            artifact_id=f"{application}:{environment}:{pipeline_id}",
+            key_alias=credential.key_alias,
+            payload=payload.encode(),
+            metadata={"environment": environment},
+        )
+        steps.append(
+            PipelineStep(
+                name="sign",
+                status="success",
+                detail=f"Signed with {credential.key_alias}",
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        # Deploy step
+        steps.append(
+            PipelineStep(
+                name="deploy",
+                status="success",
+                detail=f"Deployed to {environment}",
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+
+        execution = PipelineExecution(
+            pipeline_id=pipeline_id,
+            application=application,
+            environment=environment,
+            credential=credential,
+            artifact=artifact,
+            steps=steps,
+        )
+        self._executions[pipeline_id] = execution
+        return execution
+
+    def list_executions(self) -> Dict[str, PipelineExecution]:
+        return dict(self._executions)

--- a/modulo8_cloud_cicd/projeto/backend/requirements.txt
+++ b/modulo8_cloud_cicd/projeto/backend/requirements.txt
@@ -1,0 +1,3 @@
+cryptography==42.0.5
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo8_cloud_cicd/projeto/backend/signing.py
+++ b/modulo8_cloud_cicd/projeto/backend/signing.py
@@ -1,0 +1,43 @@
+"""Artifact signing workflow using the mock KMS."""
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict
+
+from kms import MockKMS
+
+
+@dataclass
+class SignedArtifact:
+    artifact_id: str
+    digest: str
+    signature: str
+    key_alias: str
+    signed_at: datetime
+    metadata: Dict[str, str]
+
+
+class ArtifactSigner:
+    def __init__(self, kms: MockKMS) -> None:
+        self.kms = kms
+        self._signed: Dict[str, SignedArtifact] = {}
+
+    def sign(self, artifact_id: str, key_alias: str, payload: bytes, metadata: Dict[str, str]) -> SignedArtifact:
+        digest_bytes = hashlib.sha256(payload).digest()
+        signature = self.kms.sign(key_alias, digest_bytes)
+        artifact = SignedArtifact(
+            artifact_id=artifact_id,
+            digest=base64.b64encode(digest_bytes).decode(),
+            signature=signature,
+            key_alias=key_alias,
+            signed_at=datetime.now(timezone.utc),
+            metadata=metadata,
+        )
+        self._signed[artifact_id] = artifact
+        return artifact
+
+    def list_signed(self) -> Dict[str, SignedArtifact]:
+        return dict(self._signed)

--- a/modulo8_cloud_cicd/projeto/frontend/index.html
+++ b/modulo8_cloud_cicd/projeto/frontend/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Cloud & CI/CD</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      textarea {
+        grid-column: span 3;
+        height: 120px;
+        padding: 0.5rem;
+      }
+      input,
+      button {
+        padding: 0.5rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Cloud & CI/CD</h1>
+
+    <section>
+      <h2>Executar pipeline</h2>
+      <form id="pipeline-form">
+        <input type="text" id="application" placeholder="Aplicação" required />
+        <input type="text" id="environment" placeholder="Ambiente" required />
+        <textarea id="payload" placeholder="Manifesto/artefato" required></textarea>
+        <button type="submit">Executar</button>
+      </form>
+      <pre id="pipelines"></pre>
+    </section>
+
+    <section>
+      <h2>Chaves de assinatura</h2>
+      <button id="refresh-keys">Atualizar</button>
+      <pre id="keys"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      async function refreshPipelines() {
+        const response = await fetch(`${API_BASE}/pipelines`);
+        const data = await response.json();
+        document.getElementById("pipelines").textContent = JSON.stringify(
+          data.pipelines,
+          null,
+          2
+        );
+      }
+
+      async function refreshKeys() {
+        const response = await fetch(`${API_BASE}/kms/keys`);
+        const data = await response.json();
+        document.getElementById("keys").textContent = JSON.stringify(
+          data.keys,
+          null,
+          2
+        );
+      }
+
+      document
+        .getElementById("pipeline-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/pipelines`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              application: document.getElementById("application").value,
+              environment: document.getElementById("environment").value,
+              payload: document.getElementById("payload").value,
+            }),
+          });
+          refreshPipelines();
+          refreshKeys();
+        });
+
+      document.getElementById("refresh-keys").addEventListener("click", () => {
+        refreshKeys();
+      });
+
+      refreshPipelines();
+      refreshKeys();
+    </script>
+  </body>
+</html>

--- a/modulo9_observabilidade/projeto/README.md
+++ b/modulo9_observabilidade/projeto/README.md
@@ -1,0 +1,35 @@
+# Módulo 9 &mdash; Observabilidade
+
+Implementamos um hub de observabilidade que coleta métricas, traces e logs das operações do cartório digital, permitindo inspecionar o comportamento dos módulos anteriores.
+
+## Destaques
+
+- Registro de métricas com labels e exportação em formato compatível com Prometheus.
+- Coleta de traces e logs em memória para rápida investigação.
+- API `/snapshot` que agrega todo o estado observável para dashboards.
+
+## Execução
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Frontend:
+
+```bash
+cd ../frontend
+python -m http.server 3000
+```
+
+## Validação
+
+1. Registre métricas, traces e logs via frontend ou cURL.
+2. Consulte `/snapshot` para ver o estado consolidado.
+3. Acesse `/metrics/prometheus` e valide que o formato é aceito por Prometheus.
+4. Integre as chamadas com pipelines do módulo 8 para simular monitoramento contínuo.
+
+Esse módulo finaliza a base necessária para o projeto completo do módulo 10.

--- a/modulo9_observabilidade/projeto/backend/main.py
+++ b/modulo9_observabilidade/projeto/backend/main.py
@@ -1,0 +1,81 @@
+from typing import Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from observability import ObservabilityHub
+
+
+class MetricRequest(BaseModel):
+    name: str
+    value: float
+    labels: Dict[str, str] | None = None
+
+
+class TraceRequest(BaseModel):
+    span_id: str
+    name: str
+    duration_ms: float
+    attributes: Dict[str, str] | None = None
+
+
+class LogRequest(BaseModel):
+    level: str
+    message: str
+    context: Dict[str, str] | None = None
+
+
+app = FastAPI(title="Cartório Digital - Observabilidade")
+hub = ObservabilityHub()
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok", "module": "observabilidade"}
+
+
+@app.post("/metrics")
+def record_metric(request: MetricRequest) -> Dict[str, str]:
+    labels = request.labels or {}
+    sample = hub.record_metric(request.name, request.value, **labels)
+    return {
+        "name": sample.name,
+        "value": sample.value,
+        "labels": sample.labels,
+        "recorded_at": sample.recorded_at.isoformat(),
+    }
+
+
+@app.post("/traces")
+def record_trace(request: TraceRequest) -> Dict[str, str]:
+    attributes = request.attributes or {}
+    span = hub.record_trace(request.span_id, request.name, request.duration_ms, **attributes)
+    return {
+        "span_id": span.span_id,
+        "name": span.name,
+        "duration_ms": span.duration_ms,
+        "attributes": span.attributes,
+        "timestamp": span.timestamp.isoformat(),
+    }
+
+
+@app.post("/logs")
+def record_log(request: LogRequest) -> Dict[str, str]:
+    context = request.context or {}
+    log = hub.record_log(request.level, request.message, **context)
+    return {
+        "level": log.level,
+        "message": log.message,
+        "timestamp": log.timestamp.isoformat(),
+        "context": log.context,
+    }
+
+
+@app.get("/snapshot")
+def snapshot() -> Dict[str, object]:
+    return hub.snapshot()
+
+
+@app.get("/metrics/prometheus")
+def prometheus() -> str:
+    return hub.render_prometheus()

--- a/modulo9_observabilidade/projeto/backend/observability.py
+++ b/modulo9_observabilidade/projeto/backend/observability.py
@@ -1,0 +1,104 @@
+"""In-memory observability toolkit for the lab."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List
+
+
+@dataclass
+class MetricSample:
+    name: str
+    value: float
+    labels: Dict[str, str]
+    recorded_at: datetime
+
+
+@dataclass
+class TraceSpan:
+    span_id: str
+    name: str
+    duration_ms: float
+    attributes: Dict[str, str]
+    timestamp: datetime
+
+
+@dataclass
+class LogEntry:
+    level: str
+    message: str
+    timestamp: datetime
+    context: Dict[str, str]
+
+
+class ObservabilityHub:
+    def __init__(self) -> None:
+        self.metrics: List[MetricSample] = []
+        self.traces: List[TraceSpan] = []
+        self.logs: List[LogEntry] = []
+
+    def record_metric(self, name: str, value: float, **labels: str) -> MetricSample:
+        sample = MetricSample(name=name, value=value, labels=labels, recorded_at=datetime.now(timezone.utc))
+        self.metrics.append(sample)
+        return sample
+
+    def record_trace(self, span_id: str, name: str, duration_ms: float, **attributes: str) -> TraceSpan:
+        span = TraceSpan(
+            span_id=span_id,
+            name=name,
+            duration_ms=duration_ms,
+            attributes=attributes,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.traces.append(span)
+        return span
+
+    def record_log(self, level: str, message: str, **context: str) -> LogEntry:
+        log = LogEntry(
+            level=level,
+            message=message,
+            timestamp=datetime.now(timezone.utc),
+            context=context,
+        )
+        self.logs.append(log)
+        return log
+
+    def snapshot(self) -> Dict[str, List[Dict[str, str]]]:
+        return {
+            "metrics": [
+                {
+                    "name": sample.name,
+                    "value": sample.value,
+                    "labels": sample.labels,
+                    "recorded_at": sample.recorded_at.isoformat(),
+                }
+                for sample in self.metrics
+            ],
+            "traces": [
+                {
+                    "span_id": span.span_id,
+                    "name": span.name,
+                    "duration_ms": span.duration_ms,
+                    "attributes": span.attributes,
+                    "timestamp": span.timestamp.isoformat(),
+                }
+                for span in self.traces
+            ],
+            "logs": [
+                {
+                    "level": log.level,
+                    "message": log.message,
+                    "timestamp": log.timestamp.isoformat(),
+                    "context": log.context,
+                }
+                for log in self.logs
+            ],
+        }
+
+    def render_prometheus(self) -> str:
+        lines = []
+        for sample in self.metrics:
+            label_parts = ",".join(f"{key}='{value}'" for key, value in sample.labels.items())
+            label_block = f"{{{label_parts}}}" if label_parts else ""
+            lines.append(f"{sample.name}{label_block} {sample.value}")
+        return "\n".join(lines)

--- a/modulo9_observabilidade/projeto/backend/requirements.txt
+++ b/modulo9_observabilidade/projeto/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.1
+uvicorn[standard]==0.29.0

--- a/modulo9_observabilidade/projeto/frontend/index.html
+++ b/modulo9_observabilidade/projeto/frontend/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cartório Digital - Observabilidade</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      section {
+        margin-bottom: 2rem;
+      }
+      form {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+      }
+      textarea,
+      input,
+      button {
+        padding: 0.5rem;
+      }
+      textarea {
+        grid-column: span 2;
+        height: 100px;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cartório Digital &mdash; Observabilidade</h1>
+
+    <section>
+      <h2>Métricas</h2>
+      <form id="metric-form">
+        <input type="text" id="metric-name" placeholder="Nome" required />
+        <input type="number" step="0.01" id="metric-value" placeholder="Valor" required />
+        <textarea id="metric-labels" placeholder='Labels JSON (ex: {"service": "api"})'></textarea>
+        <button type="submit">Registrar métrica</button>
+      </form>
+    </section>
+
+    <section>
+      <h2>Traces</h2>
+      <form id="trace-form">
+        <input type="text" id="span-id" placeholder="Span ID" required />
+        <input type="text" id="span-name" placeholder="Nome" required />
+        <input type="number" step="0.01" id="span-duration" placeholder="Duração (ms)" required />
+        <textarea id="span-attributes" placeholder='Atributos JSON'></textarea>
+        <button type="submit">Registrar trace</button>
+      </form>
+    </section>
+
+    <section>
+      <h2>Logs</h2>
+      <form id="log-form">
+        <input type="text" id="log-level" placeholder="Nível" required />
+        <input type="text" id="log-message" placeholder="Mensagem" required />
+        <textarea id="log-context" placeholder='Contexto JSON'></textarea>
+        <button type="submit">Registrar log</button>
+      </form>
+    </section>
+
+    <section>
+      <h2>Snapshot</h2>
+      <button id="refresh-snapshot">Atualizar</button>
+      <pre id="snapshot"></pre>
+    </section>
+
+    <section>
+      <h2>Formato Prometheus</h2>
+      <button id="refresh-prom">Atualizar métricas</button>
+      <pre id="prom"></pre>
+    </section>
+
+    <script>
+      const API_BASE = "http://localhost:8000";
+
+      function parseJsonOrEmpty(value) {
+        if (!value) return {};
+        try {
+          return JSON.parse(value);
+        } catch (err) {
+          alert("JSON inválido: " + err.message);
+          throw err;
+        }
+      }
+
+      async function refreshSnapshot() {
+        const response = await fetch(`${API_BASE}/snapshot`);
+        const data = await response.json();
+        document.getElementById("snapshot").textContent = JSON.stringify(
+          data,
+          null,
+          2
+        );
+      }
+
+      async function refreshProm() {
+        const response = await fetch(`${API_BASE}/metrics/prometheus`);
+        const text = await response.text();
+        document.getElementById("prom").textContent = text;
+      }
+
+      document
+        .getElementById("metric-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/metrics`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: document.getElementById("metric-name").value,
+              value: Number(document.getElementById("metric-value").value),
+              labels: parseJsonOrEmpty(document.getElementById("metric-labels").value),
+            }),
+          });
+          refreshSnapshot();
+          refreshProm();
+        });
+
+      document
+        .getElementById("trace-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/traces`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              span_id: document.getElementById("span-id").value,
+              name: document.getElementById("span-name").value,
+              duration_ms: Number(document.getElementById("span-duration").value),
+              attributes: parseJsonOrEmpty(document.getElementById("span-attributes").value),
+            }),
+          });
+          refreshSnapshot();
+        });
+
+      document
+        .getElementById("log-form")
+        .addEventListener("submit", async (event) => {
+          event.preventDefault();
+          await fetch(`${API_BASE}/logs`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              level: document.getElementById("log-level").value,
+              message: document.getElementById("log-message").value,
+              context: parseJsonOrEmpty(document.getElementById("log-context").value),
+            }),
+          });
+          refreshSnapshot();
+        });
+
+      document.getElementById("refresh-snapshot").addEventListener("click", () => {
+        refreshSnapshot();
+      });
+
+      document.getElementById("refresh-prom").addEventListener("click", () => {
+        refreshProm();
+      });
+
+      refreshSnapshot();
+      refreshProm();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add module-specific `projeto/` folders with backend, frontend and README snapshots
- implement PKI, TLS/mTLS, ACME automation, compliance, KMS/HSM, artifact signing, CI/CD and observability services across modules
- consolidate all capabilities into the módulo 10 final full-stack application

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5928e25b48328a03c4286099dce0b